### PR TITLE
Add `LinearMaps` support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,17 +4,26 @@ version = "0.1.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
+[weakdeps]
+LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
+
+[extensions]
+NDInterpolationsLinearMapsExt = "LinearMaps"
+
 [compat]
 Adapt = "4.3.0"
 Aqua = "0.8"
+Atomix = "1.1.1"
 DataInterpolations = "8"
 EllipsisNotation = "1.8.0"
 ForwardDiff = "0"
 KernelAbstractions = "0.9.34"
+LinearMaps = "3.11.4"
 Random = "1"
 RecipesBase = "1.3.4"
 SafeTestsets = "0.1"

--- a/ext/NDInterpolationsLinearMapsExt.jl
+++ b/ext/NDInterpolationsLinearMapsExt.jl
@@ -1,0 +1,69 @@
+module NDInterpolationsLinearMapsExt
+using NDInterpolations
+using NDInterpolations: validate_derivative_orders, get_output_size
+using LinearMaps
+
+# A linear map interp.u -> grid evaluation
+function LinearMaps.LinearMap(
+        interp::NDInterpolation{N_in}, ::Val{:grid};
+        derivative_orders::NTuple{N_in, <:Integer} = ntuple(_ -> 0, N_in)
+) where {N_in}
+    validate_derivative_orders(derivative_orders, interp)
+
+    T = NDInterpolations.output_type(interp)
+
+    grid_size = map(itp_dim -> length(itp_dim.t_eval), interp.interp_dims)
+    size_out = (grid_size..., get_output_size(interp)...)
+    N_input = length(interp.u)
+    N_output = prod(size_out)
+
+    function map!(out_flat, u_flat)
+        u_reshaped = reshape(u_flat, size(interp.u))
+        out_reshaped = reshape(out_flat, size_out)
+
+        interp_ = NDInterpolation(u_reshaped, interp.interp_dims, interp.cache)
+        eval_grid!(out_reshaped, interp_; derivative_orders)
+        return out_flat
+    end
+
+    function map_adjoint!(u_flat, out_flat)
+        u_reshaped = reshape(u_flat, size(interp.u))
+        out_reshaped = reshape(out_flat, size_out)
+
+        interp_ = NDInterpolation(u_reshaped, interp.interp_dims, interp.cache)
+        eval_grid!(out_reshaped, interp_; derivative_orders, adjoint = true)
+        return u_flat
+    end
+
+    return FunctionMap{T}(map!, map_adjoint!, N_output, N_input)
+end
+
+# A linear map interp.u -> unstructured evaluation
+function LinearMaps.LinearMap(
+        interp::NDInterpolation{N_in}, ::Val{:unstructured};
+        derivative_orders::NTuple{N_in, <:Integer} = ntuple(_ -> 0, N_in)
+) where {N_in}
+    validate_derivative_orders(derivative_orders, interp)
+
+    T = NDInterpolations.output_type(interp)
+
+    N_input = length(interp.u)
+    size_out = (length(first(interp.interp_dims).t_eval), get_output_size(interp)...)
+    N_output = prod(size_out)
+
+    function map!(out_flat, u_flat)
+        u_reshaped = reshape(u_flat, size(interp.u))
+        out_reshaped = reshape(out_flat, size_out)
+
+        interp_ = NDInterpolation(u_reshaped, interp.interp_dims, interp.cache)
+        eval_unstructured!(out_reshaped, interp_; derivative_orders)
+        return out_flat
+    end
+
+    # function map_adjoint!()
+    # end
+
+    return FunctionMap{T}(map!, N_output, N_input)
+end
+
+end # module NDInterpolationsLinearMapsExt

--- a/src/NDInterpolations.jl
+++ b/src/NDInterpolations.jl
@@ -1,5 +1,6 @@
 module NDInterpolations
-using KernelAbstractions # Keep as dependency or make extension?
+import Atomix
+using KernelAbstractions
 using Adapt: @adapt_structure
 using EllipsisNotation
 using RecipesBase
@@ -56,6 +57,7 @@ include("interpolation_dimensions.jl")
 include("spline_utils.jl")
 include("interpolation_utils.jl")
 include("interpolation_methods.jl")
+include("interpolation_methods_adjoint.jl")
 include("interpolation_parallel.jl")
 include("plot_rec.jl")
 

--- a/src/interpolation_methods_adjoint.jl
+++ b/src/interpolation_methods_adjoint.jl
@@ -1,0 +1,39 @@
+function _interpolate_adjoint!(
+        A::NDInterpolation{N_in, N_out, ID},
+        out,
+        t::Tuple{Vararg{Number, N_in}},
+        idx::NTuple{N_in, <:Integer},
+        derivative_orders::NTuple{N_in, <:Integer},
+        multi_point_index
+)::Nothing where {N_in, N_out, ID <: LinearInterpolationDimension}
+    any(>(1), derivative_orders) && return out
+
+    tᵢ = ntuple(i -> A.interp_dims[i].t[idx[i]], N_in)
+    tᵢ₊₁ = ntuple(i -> A.interp_dims[i].t[idx[i] + 1], N_in)
+
+    # Size of the (hyper)rectangle `t` is in
+    t_vol = one(eltype(tᵢ))
+    for (t₁, t₂) in zip(tᵢ, tᵢ₊₁)
+        t_vol *= t₂ - t₁
+    end
+
+    # Loop over the corners of the (hyper)rectangle `t` is in
+    for I in Iterators.product(ntuple(i -> (false, true), N_in)...)
+        c = eltype(out)(inv(t_vol))
+        for (t_, right_point, d, t₁, t₂) in zip(t, I, derivative_orders, tᵢ, tᵢ₊₁)
+            c *= if right_point
+                iszero(d) ? t_ - t₁ : one(t_)
+            else
+                iszero(d) ? t₂ - t_ : -one(t_)
+            end
+        end
+        J = (ntuple(i -> idx[i] + I[i], N_in)..., ..)
+
+        if iszero(N_out)
+            Atomix.@atomic A.u[J...] += c * out
+        else
+            Atomix.@atomic A.u[J...] += c * out
+        end
+    end
+    return nothing
+end

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -87,19 +87,29 @@ function make_zero!!(v::T) where {T <: AbstractArray}
     v
 end
 
+function output_type(interp::NDInterpolation)
+    promote_type(eltype(interp.u), map(itp_dim -> eltype(itp_dim.t), interp.interp_dims)...)
+end
+
+function output_type(
+        interp::NDInterpolation{N_in},
+        t::NTuple{N_in, >:Number}
+) where {N_in}
+    promote_type(output_type(interp), map(typeof, t)...)
+end
+
 function make_out(
         interp::NDInterpolation{N_in, 0},
         t::NTuple{N_in, >:Number}
 ) where {N_in}
-    zero(promote_type(eltype(interp.u), map(typeof, t)...))
+    zero(output_type(interp, t))
 end
 
 function make_out(
         interp::NDInterpolation{N_in},
         t::NTuple{N_in, >:Number}
 ) where {N_in}
-    similar(
-        interp.u, promote_type(eltype(interp.u), map(eltype, t)...), get_output_size(interp))
+    similar(interp.u, ouput_type(interp, t))
 end
 
 get_left(::AbstractInterpolationDimension) = false


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Fixes https://github.com/SciML/NDInterpolations.jl/issues/4. Interpolations are virtually always linear combinations of `u`, which makes the operation `u` -> 'set of evaluation points' a linear operation. This can be used by wrapping an `NDInterpolation` object in a `LinearMap` object, for instance to do least squares fitting:

Example:

```julia
using NDInterpolations
using LinearMaps
using IterativeSolvers
using CairoMakie

x = range(-4, 4, length=100)
y = range(-4, 4, length=100)
z = (sin.(2x) .+ sin.(2y')) .^ 2

Nx = 15
Ny = 15

itp_dims = (
    LinearInterpolationDimension(collect(range(-4, 4; length=Nx)), t_eval=x),
    LinearInterpolationDimension(collect(range(-4, 4, length=Ny)), t_eval=y)
)

u = zeros(Nx, Ny)
itp = NDInterpolation(u, itp_dims)

linear_map = LinearMap(itp, Val(:grid))
sol = lsqr(linear_map, vec(z))

itp_opt = NDInterpolation(reshape(sol, Nx, Ny), itp_dims)
out = eval_grid(itp_opt)

f = Figure()
ax_target = Axis(f[1, 1]; title="Target", aspect=1)
colorrange = (-1, 5)
heatmap!(ax_target, z; colorrange)

ax_fit = Axis(f[1, 2]; title="Piecewise linear fit", aspect=1)
heatmap!(ax_fit, out; colorrange)

f
```

![image](https://github.com/user-attachments/assets/1a4477d4-aa57-414c-a814-2be2bca34ac5)