### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
+      - 'master'
       - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(
         "Usage" => "usage.md",
         "Interpolation Types" => "interpolation_types.md",
         "Splines" => "splines.md",
-        "API" => "api.md"
+        "API" => "api.md",
     ]
 )
 

--- a/ext/DataInterpolationsNDSymbolicsExt.jl
+++ b/ext/DataInterpolationsNDSymbolicsExt.jl
@@ -18,8 +18,11 @@ Base.nameof(::NDInterpolation) = :NDInterpolation
 Base.nameof(::DifferentiatedNDInterpolation) = :DifferentiatedNDInterpolation
 
 for symT in [Num, Symbolic{<:Real}]
-    @eval function (interp::NDInterpolation{N_in, N_out})(t::Vararg{
-            $symT, N_in}) where {N_in, N_out}
+    @eval function (interp::NDInterpolation{N_in, N_out})(
+            t::Vararg{
+                $symT, N_in,
+            }
+        ) where {N_in, N_out}
         if $(symT === Num)
             t = unwrap.(t)
         end
@@ -28,7 +31,8 @@ for symT in [Num, Symbolic{<:Real}]
         else
             Symbolics.array_term(
                 interp, t...; eltype = Real, container_type = Array, ndims = N_out,
-                size = DataInterpolationsND.get_output_size(interp))
+                size = DataInterpolationsND.get_output_size(interp)
+            )
         end
         if $(symT === Num)
             if N_out == 0
@@ -39,8 +43,11 @@ for symT in [Num, Symbolic{<:Real}]
         end
         return res
     end
-    @eval function (interp::DifferentiatedNDInterpolation{N_in, N_out})(t::Vararg{
-            $symT, N_in}) where {N_in, N_out}
+    @eval function (interp::DifferentiatedNDInterpolation{N_in, N_out})(
+            t::Vararg{
+                $symT, N_in,
+            }
+        ) where {N_in, N_out}
         if $(symT === Num)
             t = unwrap.(t)
         end
@@ -49,7 +56,8 @@ for symT in [Num, Symbolic{<:Real}]
         else
             Symbolics.array_term(
                 interp, t...; eltype = Real, container_type = Array, ndims = N_out,
-                size = DataInterpolationsND.get_output_size(interp.interp))
+                size = DataInterpolationsND.get_output_size(interp.interp)
+            )
         end
         if $(symT === Num)
             if N_out == 0
@@ -62,20 +70,25 @@ for symT in [Num, Symbolic{<:Real}]
     end
 end
 function SymbolicUtils.promote_symtype(::NDInterpolation{N_in, N_out}, ::Vararg) where {
-        N_in, N_out}
-    N_out == 0 ? Real : Array{Real, N_out}
+        N_in, N_out,
+    }
+    return N_out == 0 ? Real : Array{Real, N_out}
 end
 
-function Symbolics.derivative(interp::NDInterpolation{N_in, N_out},
-        args::NTuple{N_in, Any}, ::Val{I}) where {N_in, N_out, I}
+function Symbolics.derivative(
+        interp::NDInterpolation{N_in, N_out},
+        args::NTuple{N_in, Any}, ::Val{I}
+    ) where {N_in, N_out, I}
     @assert I <= N_in
     orders = ntuple(Int ∘ isequal(I), Val{N_in}())
     dinterp = DifferentiatedNDInterpolation{N_in, N_out, typeof(interp)}(interp, orders)
     return dinterp(args...)
 end
 
-function Symbolics.derivative(interp::DifferentiatedNDInterpolation{N_in, N_out},
-        args::NTuple{N_in, Any}, ::Val{I}) where {N_in, N_out, I}
+function Symbolics.derivative(
+        interp::DifferentiatedNDInterpolation{N_in, N_out},
+        args::NTuple{N_in, Any}, ::Val{I}
+    ) where {N_in, N_out, I}
     @assert I <= N_in
     orders_offset = ntuple(Int ∘ isequal(I), Val{N_in}())
     orders = interp.derivative_orders .+ orders_offset

--- a/src/DataInterpolationsND.jl
+++ b/src/DataInterpolationsND.jl
@@ -1,6 +1,6 @@
 module DataInterpolationsND
 using KernelAbstractions: KernelAbstractions, @Const, @index, @kernel, get_backend,
-                          synchronize
+    synchronize
 using Adapt: @adapt_structure
 using EllipsisNotation: EllipsisNotation, (..)
 using RecipesBase: RecipesBase, @recipe, @series
@@ -27,11 +27,11 @@ the size of `u` along that dimension must match the length of `t` of the corresp
   - `cache`: Optional global cache
 """
 struct NDInterpolation{
-    N_in, N_out,
-    ID <: AbstractInterpolationDimension,
-    gType <: AbstractInterpolationCache,
-    uType <: AbstractArray
-}
+        N_in, N_out,
+        ID <: AbstractInterpolationDimension,
+        gType <: AbstractInterpolationCache,
+        uType <: AbstractArray,
+    }
     u::uType
     interp_dims::NTuple{N_in, ID}
     cache::gType
@@ -41,10 +41,10 @@ struct NDInterpolation{
         end
         N_in = length(interp_dims)
         N_out = ndims(u) - N_in
-        @assert N_out≥0 "The number of dimensions of u must be at least the number of interpolation dimensions."
+        @assert N_out ≥ 0 "The number of dimensions of u must be at least the number of interpolation dimensions."
         validate_size_u(interp_dims, u)
         validate_cache(cache, interp_dims, u)
-        new{N_in, N_out, eltype(interp_dims), typeof(cache), typeof(u)}(
+        return new{N_in, N_out, eltype(interp_dims), typeof(cache), typeof(u)}(
             u, interp_dims, cache
         )
     end
@@ -52,7 +52,7 @@ end
 
 # Constructor with optional global cache
 function NDInterpolation(u, interp_dims; cache = EmptyCache())
-    NDInterpolation(u, interp_dims, cache)
+    return NDInterpolation(u, interp_dims, cache)
 end
 
 @adapt_structure NDInterpolation
@@ -66,12 +66,13 @@ include("plot_rec.jl")
 
 # Multiple `t` arguments to tuple (can these 2 be done in 1?)
 function (interp::NDInterpolation)(t_args::Vararg{Number}; kwargs...)
-    interp(t_args; kwargs...)
+    return interp(t_args; kwargs...)
 end
 
 function (interp::NDInterpolation)(
-        out::AbstractArray, t_args::Vararg{Number}; kwargs...)
-    interp(out, t_args; kwargs...)
+        out::AbstractArray, t_args::Vararg{Number}; kwargs...
+    )
+    return interp(out, t_args; kwargs...)
 end
 
 # In place single input evaluation
@@ -79,22 +80,22 @@ function (interp::NDInterpolation{N_in})(
         out::Union{Number, AbstractArray{<:Number}},
         t::Tuple{Vararg{Number, N_in}};
         derivative_orders::NTuple{N_in, <:Integer} = ntuple(_ -> 0, N_in)
-) where {N_in}
+    ) where {N_in}
     validate_derivative_orders(derivative_orders, interp)
     idx = get_idx(interp.interp_dims, t)
-    @assert size(out)==size(interp.u)[(N_in + 1):end] "The size of out must match the size of the last N_out dimensions of u."
-    _interpolate!(out, interp, t, idx, derivative_orders, nothing)
+    @assert size(out) == size(interp.u)[(N_in + 1):end] "The size of out must match the size of the last N_out dimensions of u."
+    return _interpolate!(out, interp, t, idx, derivative_orders, nothing)
 end
 
 # Out of place single input evaluation
 function (interp::NDInterpolation)(t::Tuple{Vararg{Number}}; kwargs...)
     out = make_out(interp, t)
-    interp(out, t; kwargs...)
+    return interp(out, t; kwargs...)
 end
 
 export NDInterpolation, LinearInterpolationDimension, ConstantInterpolationDimension,
-       BSplineInterpolationDimension, NURBSWeights,
-       eval_unstructured, eval_unstructured!, eval_grid, eval_grid!
+    BSplineInterpolationDimension, NURBSWeights,
+    eval_unstructured, eval_unstructured!, eval_grid, eval_grid!
 
 include("precompilation.jl")
 

--- a/src/interpolation_dimensions.jl
+++ b/src/interpolation_dimensions.jl
@@ -13,16 +13,16 @@ Interpolation dimension for linear interpolation between the data points.
     see `eval_unstructured` and `eval_grid`. Defaults to no points.
 """
 struct LinearInterpolationDimension{
-    tType <: AbstractVector{<:Number},
-    t_evalType <: AbstractVector{<:Number},
-    idxType <: AbstractVector{<:Integer}
-} <: AbstractInterpolationDimension
+        tType <: AbstractVector{<:Number},
+        t_evalType <: AbstractVector{<:Number},
+        idxType <: AbstractVector{<:Integer},
+    } <: AbstractInterpolationDimension
     t::tType
     t_eval::t_evalType
     idx_eval::idxType
     function LinearInterpolationDimension(t, t_eval, idx_eval)
         validate_t(t)
-        new{typeof(t), typeof(t_eval), typeof(idx_eval)}(t, t_eval, idx_eval)
+        return new{typeof(t), typeof(t_eval), typeof(idx_eval)}(t, t_eval, idx_eval)
     end
 end
 
@@ -34,7 +34,7 @@ function LinearInterpolationDimension(t; t_eval = similar(t, 0))
         t, t_eval, idx_eval
     )
     set_eval_idx!(itp_dim)
-    itp_dim
+    return itp_dim
 end
 
 """
@@ -53,17 +53,17 @@ Interpolation dimension for constant interpolation between the data points.
     see `eval_unstructured` and `eval_grid`. Defaults to no points.
 """
 struct ConstantInterpolationDimension{
-    tType <: AbstractVector{<:Number},
-    t_evalType <: AbstractVector{<:Number},
-    idxType <: AbstractVector{<:Integer}
-} <: AbstractInterpolationDimension
+        tType <: AbstractVector{<:Number},
+        t_evalType <: AbstractVector{<:Number},
+        idxType <: AbstractVector{<:Integer},
+    } <: AbstractInterpolationDimension
     t::tType
     left::Bool
     t_eval::t_evalType
     idx_eval::idxType
     function ConstantInterpolationDimension(t, left, t_eval, idx_eval)
         validate_t(t)
-        new{typeof(t), typeof(t_eval), typeof(idx_eval)}(
+        return new{typeof(t), typeof(t_eval), typeof(idx_eval)}(
             t, left, t_eval, idx_eval
         )
     end
@@ -77,7 +77,7 @@ function ConstantInterpolationDimension(t; left = true, t_eval = similar(t, 0))
         t, left, t_eval, idx_eval
     )
     set_eval_idx!(itp_dim)
-    itp_dim
+    return itp_dim
 end
 
 """
@@ -104,12 +104,12 @@ the BSpline basis functions.
   - `multiplicities`: The multiplicities of the knots `t`. Defaults to multiplicities for an open/clamped knot vector.
 """
 struct BSplineInterpolationDimension{
-    tType <: AbstractVector{<:Number},
-    t_evalType <: AbstractVector{<:Number},
-    idxType <: AbstractVector{<:Integer},
-    evalType <: AbstractArray{<:Number, 3},
-    mType <: AbstractVector{<:Integer}
-} <: AbstractInterpolationDimension
+        tType <: AbstractVector{<:Number},
+        t_evalType <: AbstractVector{<:Number},
+        idxType <: AbstractVector{<:Integer},
+        evalType <: AbstractArray{<:Number, 3},
+        mType <: AbstractVector{<:Integer},
+    } <: AbstractInterpolationDimension
     t::tType
     knots_all::tType
     t_eval::t_evalType
@@ -120,12 +120,16 @@ struct BSplineInterpolationDimension{
     multiplicities::mType
     function BSplineInterpolationDimension(
             t, knots_all, t_eval, idx_eval, degree, max_derivative_order_eval,
-            basis_function_eval, multiplicities)
+            basis_function_eval, multiplicities
+        )
         validate_t(t)
-        new{typeof(t), typeof(t_eval), typeof(idx_eval),
-            typeof(basis_function_eval), typeof(multiplicities)}(
+        return new{
+            typeof(t), typeof(t_eval), typeof(idx_eval),
+            typeof(basis_function_eval), typeof(multiplicities),
+        }(
             t, knots_all, t_eval, idx_eval, degree, max_derivative_order_eval,
-            basis_function_eval, multiplicities)
+            basis_function_eval, multiplicities
+        )
     end
 end
 
@@ -136,14 +140,14 @@ function BSplineInterpolationDimension(
         t_eval = similar(t, 0),
         max_derivative_order_eval::Integer = 0,
         multiplicities::Union{AbstractVector{<:Integer}, Nothing} = nothing
-)
+    )
     if isnothing(multiplicities)
         # Multiplicities for open/clamped knot vector if no multiplicities are provided
         multiplicities = similar(t, Int)
         multiplicities .= 1
         multiplicities[[1, length(multiplicities)]] .= degree + 1
     end
-    @assert length(multiplicities)==length(t) "There must be the same amount of knots (points in t) as multiplicities."
+    @assert length(multiplicities) == length(t) "There must be the same amount of knots (points in t) as multiplicities."
     @assert all(m -> 1 ≤ m ≤ (degree + 1), multiplicities) "All multiplicities must be between 1 and degree + 1."
 
     knots_all = similar(t, sum(multiplicities))
@@ -163,13 +167,14 @@ function BSplineInterpolationDimension(
         (
             length(t_eval),
             degree + 1,
-            max_derivative_order_eval + 1
+            max_derivative_order_eval + 1,
         )
     )
     itp_dim = BSplineInterpolationDimension(
         t, knots_all, t_eval, idx_eval, degree, max_derivative_order_eval,
-        basis_function_eval, multiplicities)
+        basis_function_eval, multiplicities
+    )
     set_eval_idx!(itp_dim)
     set_basis_function_eval!(itp_dim)
-    itp_dim
+    return itp_dim
 end

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -5,7 +5,7 @@ function _interpolate!(
         idx::NTuple{N_in, <:Integer},
         derivative_orders::NTuple{N_in, <:Integer},
         multi_point_index
-) where {N_in, N_out, ID <: LinearInterpolationDimension}
+    ) where {N_in, N_out, ID <: LinearInterpolationDimension}
     out = make_zero!!(out)
     any(>(1), derivative_orders) && return out
 
@@ -45,7 +45,7 @@ function _interpolate!(
         idx::NTuple{N_in, <:Integer},
         derivative_orders::NTuple{N_in, <:Integer},
         multi_point_index
-) where {N_in, N_out, ID <: ConstantInterpolationDimension}
+    ) where {N_in, N_out, ID <: ConstantInterpolationDimension}
     if any(>(0), derivative_orders)
         return if any(i -> !isempty(searchsorted(A.interp_dims[i].t, t[i])), 1:N_in)
             typed_nan(out)
@@ -73,7 +73,7 @@ function _interpolate!(
         idx::NTuple{N_in, <:Integer},
         derivative_orders::NTuple{N_in, <:Integer},
         multi_point_index
-) where {N_in, N_out, ID <: BSplineInterpolationDimension}
+    ) where {N_in, N_out, ID <: BSplineInterpolationDimension}
     (; interp_dims) = A
 
     out = make_zero!!(out)
@@ -85,7 +85,8 @@ function _interpolate!(
     for I in CartesianIndices(ntuple(dim_in -> 1:(degrees[dim_in] + 1), N_in))
         B_product = prod(dim_in -> basis_function_vals[dim_in][I[dim_in]], 1:N_in)
         cp_index = ntuple(
-            dim_in -> idx[dim_in] + I[dim_in] - degrees[dim_in] - 1, N_in)
+            dim_in -> idx[dim_in] + I[dim_in] - degrees[dim_in] - 1, N_in
+        )
         if iszero(N_out)
             out += B_product * A.u[cp_index...]
         else
@@ -104,7 +105,7 @@ function _interpolate!(
         idx::NTuple{N_in, <:Integer},
         derivative_orders::NTuple{N_in, <:Integer},
         multi_point_index
-) where {N_in, N_out, ID <: BSplineInterpolationDimension}
+    ) where {N_in, N_out, ID <: BSplineInterpolationDimension}
     (; interp_dims, cache) = A
 
     out = make_zero!!(out)
@@ -118,7 +119,8 @@ function _interpolate!(
     for I in CartesianIndices(ntuple(dim_in -> 1:(degrees[dim_in] + 1), N_in))
         B_product = prod(dim_in -> basis_function_vals[dim_in][I[dim_in]], 1:N_in)
         cp_index = ntuple(
-            dim_in -> idx[dim_in] + I[dim_in] - degrees[dim_in] - 1, N_in)
+            dim_in -> idx[dim_in] + I[dim_in] - degrees[dim_in] - 1, N_in
+        )
         weight = cache.weights[cp_index...]
         product = weight * B_product
         denom += product

--- a/src/interpolation_parallel.jl
+++ b/src/interpolation_parallel.jl
@@ -14,7 +14,7 @@ length for each interpolation dimension and the interpolation is evaluated at th
 function eval_unstructured(interp::NDInterpolation; kwargs...)
     n_points = length(first(interp.interp_dims).t_eval)
     out = similar(interp.u, (n_points, get_output_size(interp)...))
-    eval_unstructured!(out, interp; kwargs...)
+    return eval_unstructured!(out, interp; kwargs...)
 end
 
 """
@@ -35,11 +35,11 @@ function eval_unstructured!(
         out::AbstractArray,
         interp::NDInterpolation{N_in};
         derivative_orders::NTuple{N_in, <:Integer} = ntuple(_ -> 0, N_in)
-) where {N_in}
+    ) where {N_in}
     validate_derivative_orders(derivative_orders, interp; multi_point = true)
     backend = get_backend(out)
     @assert all(i -> length(interp.interp_dims[i].t_eval) == size(out, 1), N_in) "The t_eval of all interpolation dimensions must have the same length as the first dimension of out."
-    @assert size(out)[2:end]==get_output_size(interp) "The size of the last N_out dimensions of out must be the same as the output size of the interpolation."
+    @assert size(out)[2:end] == get_output_size(interp) "The size of the last N_out dimensions of out must be the same as the output size of the interpolation."
     eval_kernel(backend)(
         out,
         interp,
@@ -66,7 +66,7 @@ out of place.
 function eval_grid(interp::NDInterpolation{N_in}; kwargs...) where {N_in}
     grid_size = map(itp_dim -> length(itp_dim.t_eval), interp.interp_dims)
     out = similar(interp.u, (grid_size..., get_output_size(interp)...))
-    eval_grid!(out, interp; kwargs...)
+    return eval_grid!(out, interp; kwargs...)
 end
 
 """
@@ -86,11 +86,11 @@ function eval_grid!(
         out::AbstractArray,
         interp::NDInterpolation{N_in};
         derivative_orders::NTuple{N_in, <:Integer} = ntuple(_ -> 0, N_in)
-) where {N_in}
+    ) where {N_in}
     validate_derivative_orders(derivative_orders, interp; multi_point = true)
     backend = get_backend(out)
     @assert all(i -> size(out, i) == length(interp.interp_dims[i].t_eval), N_in) "For the first N_in dimensions of out the length must match the t_eval of the corresponding interpolation dimension."
-    @assert size(out)[(N_in + 1):end]==get_output_size(interp) "The size of the last N_out dimensions of out must be the same as the output size of the interpolation."
+    @assert size(out)[(N_in + 1):end] == get_output_size(interp) "The size of the last N_out dimensions of out must be the same as the output size of the interpolation."
     eval_kernel(backend)(
         out,
         interp,
@@ -107,7 +107,7 @@ end
         @Const(A),
         derivative_orders,
         eval_grid
-)
+    )
     N_in = length(A.interp_dims)
     N_out = ndims(A.u) - N_in
 
@@ -123,10 +123,12 @@ end
 
     if iszero(N_out)
         out[k...] = _interpolate!(
-            make_out(A, t_eval), A, t_eval, idx_eval, derivative_orders, k)
+            make_out(A, t_eval), A, t_eval, idx_eval, derivative_orders, k
+        )
     else
         _interpolate!(
             view(out, k..., ..),
-            A, t_eval, idx_eval, derivative_orders, k)
+            A, t_eval, idx_eval, derivative_orders, k
+        )
     end
 end

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -6,15 +6,15 @@ function validate_derivative_orders(
         derivative_orders::NTuple{N_in, <:Integer},
         ::NDInterpolation{N_in};
         kwargs...
-) where {N_in}
-    @assert all(≥(0), derivative_orders) "Derivative orders must me non-negative."
+    ) where {N_in}
+    return @assert all(≥(0), derivative_orders) "Derivative orders must me non-negative."
 end
 
 function validate_derivative_orders(
         derivative_orders::NTuple{N_in, <:Integer},
         A::NDInterpolation{N_in, N_out, <:BSplineInterpolationDimension};
         multi_point::Bool = false
-) where {N_in, N_out}
+    ) where {N_in, N_out}
     @assert all(≥(0), derivative_orders) "Derivative orders must me non-negative."
 
     if multi_point
@@ -26,80 +26,85 @@ function validate_derivative_orders(
         `BSplineInterpolationDimension` constructor(s)."
     end
 
-    if A.cache isa NURBSWeights
+    return if A.cache isa NURBSWeights
         @assert all(==(0), derivative_orders) "Currently partial derivatives of NURBS are not supported."
     end
 end
 
 function validate_t(t)
     @assert t isa AbstractVector{<:Number} "t must be an AbstractVector with number like elements."
-    @assert all(>(0), diff(t)) "The elements of t must be sorted and unique."
+    return @assert all(>(0), diff(t)) "The elements of t must be sorted and unique."
 end
 
 function validate_size_u(
         interp_dims::NTuple{N_in, <:AbstractInterpolationDimension},
         u::AbstractArray
-) where {N_in}
-    @assert ntuple(i -> length(interp_dims[i]), N_in)==size(u)[1:N_in] "For the first N_in dimensions of u the length must match the t of the corresponding interpolation dimension."
+    ) where {N_in}
+    return @assert ntuple(i -> length(interp_dims[i]), N_in) == size(u)[1:N_in] "For the first N_in dimensions of u the length must match the t of the corresponding interpolation dimension."
 end
 
 function validate_size_u(
         interp_dims::NTuple{N_in, <:BSplineInterpolationDimension},
         u::AbstractArray
-) where {N_in}
+    ) where {N_in}
     expected_size = ntuple(dim_in -> get_n_basis_functions(interp_dims[dim_in]), N_in)
-    @assert expected_size==size(u)[1:N_in] "Expected the size of the first N_in dimensions of u to be $expected_size based on the BSplineInterpolation properties."
+    return @assert expected_size == size(u)[1:N_in] "Expected the size of the first N_in dimensions of u to be $expected_size based on the BSplineInterpolation properties."
 end
 
 function validate_cache(
         ::EmptyCache, ::NTuple{N_in, ID}, ::AbstractArray
-) where {N_in, ID}
-    nothing
+    ) where {N_in, ID}
+    return nothing
 end
 
 function validate_cache(
         nurbs_weights::NURBSWeights,
         ::NTuple{N_in, BSplineInterpolationDimension},
         u::AbstractArray
-) where {N_in}
+    ) where {N_in}
     size_expected = size(u)[1:N_in]
-    @assert size(nurbs_weights.weights)==size_expected "The size of the weights array must match the length of the first N_in dimensions of u ($size_expected)."
+    return @assert size(nurbs_weights.weights) == size_expected "The size of the weights array must match the length of the first N_in dimensions of u ($size_expected)."
 end
 
 function validate_cache(
-        ::gType, ::NTuple{N_in, ID}, ::AbstractArray) where {gType, N_in, ID}
-    @error("Interpolation dimension type $ID is not compatible with global cache type $gType.")
+        ::gType, ::NTuple{N_in, ID}, ::AbstractArray
+    ) where {gType, N_in, ID}
+    return @error("Interpolation dimension type $ID is not compatible with global cache type $gType.")
 end
 
-function get_ts(interp_dims::NTuple{
-        N_in, AbstractInterpolationDimension}) where {N_in}
-    ntuple(i -> interp_dims[i].t, N_in)
+function get_ts(
+        interp_dims::NTuple{
+            N_in, AbstractInterpolationDimension,
+        }
+    ) where {N_in}
+    return ntuple(i -> interp_dims[i].t, N_in)
 end
 
 function get_output_size(interp::NDInterpolation{N_in}) where {N_in}
-    size(interp.u)[(N_in + 1):end]
+    return size(interp.u)[(N_in + 1):end]
 end
 
 make_zero!!(::T) where {T <: Number} = zero(T)
 
 function make_zero!!(v::T) where {T <: AbstractArray}
     v .= 0
-    v
+    return v
 end
 
 function make_out(
         interp::NDInterpolation{N_in, 0},
         t::NTuple{N_in, >:Number}
-) where {N_in}
-    zero(promote_type(eltype(interp.u), map(typeof, t)...))
+    ) where {N_in}
+    return zero(promote_type(eltype(interp.u), map(typeof, t)...))
 end
 
 function make_out(
         interp::NDInterpolation{N_in},
         t::NTuple{N_in, >:Number}
-) where {N_in}
-    similar(
-        interp.u, promote_type(eltype(interp.u), map(eltype, t)...), get_output_size(interp))
+    ) where {N_in}
+    return similar(
+        interp.u, promote_type(eltype(interp.u), map(eltype, t)...), get_output_size(interp)
+    )
 end
 
 get_left(::AbstractInterpolationDimension) = false
@@ -107,7 +112,7 @@ get_left(::LinearInterpolationDimension) = true
 
 get_idx_bounds(::AbstractInterpolationDimension) = (1, -1)
 function get_idx_bounds(itp_dim::BSplineInterpolationDimension)
-    (itp_dim.degree + 1, -itp_dim.degree - 1)
+    return (itp_dim.degree + 1, -itp_dim.degree - 1)
 end
 
 get_idx_shift(::AbstractInterpolationDimension) = 0
@@ -117,7 +122,7 @@ get_idx_shift(::LinearInterpolationDimension) = -1
 function get_idx(
         interp_dim::AbstractInterpolationDimension,
         t_eval::Number
-)
+    )
     t = if interp_dim isa BSplineInterpolationDimension
         interp_dim.knots_all
     else
@@ -136,14 +141,14 @@ end
 
 function get_idx(
         interp_dims::NTuple{N_in},
-        t::Tuple{Vararg{Number, N_in}};
-) where {N_in}
-    ntuple(dim_in -> get_idx(interp_dims[dim_in], t[dim_in]), N_in)
+        t::Tuple{Vararg{Number, N_in}}
+    ) where {N_in}
+    return ntuple(dim_in -> get_idx(interp_dims[dim_in], t[dim_in]), N_in)
 end
 
 function set_eval_idx!(
         interp_dim::AbstractInterpolationDimension,
-)
+    )
     backend = get_backend(interp_dim.t)
     if !isempty(interp_dim.t_eval)
         set_idx_kernel(backend)(
@@ -151,22 +156,22 @@ function set_eval_idx!(
             ndrange = length(interp_dim.t_eval)
         )
     end
-    synchronize(backend)
+    return synchronize(backend)
 end
 
 @kernel function set_idx_kernel(
         interp_dim
-)
+    )
     i = @index(Global, Linear)
     interp_dim.idx_eval[i] = get_idx(interp_dim, interp_dim.t_eval[i])
 end
 
 function typed_nan(x::AbstractArray{T}) where {T <: AbstractFloat}
-    x .= NaN
+    return x .= NaN
 end
 
 function typed_nan(x::AbstractArray{T}) where {T <: Integer}
-    x .= 0
+    return x .= 0
 end
 
 typed_nan(::T) where {T <: Integer} = zero(T)

--- a/src/spline_utils.jl
+++ b/src/spline_utils.jl
@@ -2,7 +2,7 @@
         knots_all,
         @Const(knot_values),
         @Const(multiplicities)
-)
+    )
     i = @index(Global, Linear)
     knot_value = knot_values[i]
 
@@ -23,9 +23,9 @@ safe_div(a, b) = iszero(b) ? zero(promote_type(typeof(a), typeof(b))) : a / b
 
 function cox_de_boor(
         basis_function_values, knots_all, t, idx, degree, d, k, deriv
-)
+    )
     T = eltype(basis_function_values)
-    if (k ≤ degree - d) || (k == degree + 2)
+    return if (k ≤ degree - d) || (k == degree + 2)
         zero(T)
     else
         i = idx + k - degree - 1
@@ -34,11 +34,17 @@ function cox_de_boor(
         tᵢ₊ₚ = knots_all[i + d]
         tᵢ₊ₚ₊₁ = knots_all[i + d + 1]
         if deriv
-            T(d * (safe_div(basis_function_values[k], tᵢ₊ₚ - tᵢ) -
-               safe_div(basis_function_values[k + 1], tᵢ₊ₚ₊₁ - tᵢ₊₁)))
+            T(
+                d * (
+                    safe_div(basis_function_values[k], tᵢ₊ₚ - tᵢ) -
+                        safe_div(basis_function_values[k + 1], tᵢ₊ₚ₊₁ - tᵢ₊₁)
+                )
+            )
         else
-            T(basis_function_values[k] * safe_div(t - tᵢ, tᵢ₊ₚ - tᵢ) +
-              basis_function_values[k + 1] * safe_div(tᵢ₊ₚ₊₁ - t, tᵢ₊ₚ₊₁ - tᵢ₊₁))
+            T(
+                basis_function_values[k] * safe_div(t - tᵢ, tᵢ₊ₚ - tᵢ) +
+                    basis_function_values[k + 1] * safe_div(tᵢ₊ₚ₊₁ - t, tᵢ₊ₚ₊₁ - tᵢ₊₁)
+            )
         end
     end
 end
@@ -53,7 +59,7 @@ end
 # (0, …, 0, Bⱼ₋₁ ₁, Bⱼ₁, 0)
 #          ⋮
 # (Bⱼ₋ₚ ₚ, Bⱼ₋ₚ₊₁ ₚ, …, Bⱼₚ, 0)
-# 
+#
 # The trailing zero is just a convenience for the algorithm and is removed in the output
 function get_basis_function_values(
         itp_dim::BSplineInterpolationDimension,
@@ -62,7 +68,7 @@ function get_basis_function_values(
         derivative_order::Integer,
         multi_point_index::Nothing,
         dim_in::Integer
-)
+    )
     (; degree, knots_all) = itp_dim
     T = promote_type(typeof(t), eltype(itp_dim.basis_function_eval))
     degree_plus_1 = degree + 1
@@ -90,7 +96,7 @@ function get_basis_function_values(
         )
     end
 
-    basis_function_values[1:degree_plus_1]
+    return basis_function_values[1:degree_plus_1]
 end
 
 # Get the basis function values for one point in an
@@ -102,9 +108,11 @@ function get_basis_function_values(
         derivative_order::Integer,
         multi_point_index::Number,
         dim_in::Integer
-)
-    view(itp_dim.basis_function_eval,
-        multi_point_index, :, derivative_order + 1)
+    )
+    return view(
+        itp_dim.basis_function_eval,
+        multi_point_index, :, derivative_order + 1
+    )
 end
 
 # Get the basis function values for one point in a
@@ -116,9 +124,11 @@ function get_basis_function_values(
         derivative_order::Integer,
         multi_point_index::NTuple{N_in, <:Integer},
         dim_in::Integer
-) where {N_in}
-    view(itp_dim.basis_function_eval,
-        multi_point_index[dim_in], :, derivative_order + 1)
+    ) where {N_in}
+    return view(
+        itp_dim.basis_function_eval,
+        multi_point_index[dim_in], :, derivative_order + 1
+    )
 end
 
 # Get all basis function values to evaluate a BSpline interpolation in t
@@ -128,8 +138,8 @@ function get_basis_function_values_all(
         idx::NTuple{N_in, <:Integer},
         derivative_orders::NTuple{N_in, <:Integer},
         multi_point_index
-) where {N_in, N_out}
-    ntuple(
+    ) where {N_in, N_out}
+    return ntuple(
         dim_in -> get_basis_function_values(
             A.interp_dims[dim_in], t[dim_in], idx[dim_in], derivative_orders[dim_in], multi_point_index, dim_in
         ),
@@ -149,12 +159,14 @@ end
 
 @kernel function basis_function_eval_kernel(
         itp_dim
-)
+    )
     i, derivative_order_plus_1 = @index(Global, NTuple)
 
-    itp_dim.basis_function_eval[i,
-    :,
-    derivative_order_plus_1] .= get_basis_function_values(
+    itp_dim.basis_function_eval[
+        i,
+        :,
+        derivative_order_plus_1,
+    ] .= get_basis_function_values(
         itp_dim,
         itp_dim.t_eval[i],
         itp_dim.idx_eval[i],
@@ -165,16 +177,16 @@ end
 end
 
 # Wrapper for a BSplineInterpolationDimension which acts as a vector of the values
-# of the i-th basis function in the `itp_dim.t_eval`. 
+# of the i-th basis function in the `itp_dim.t_eval`.
 struct BasisFunctionVector{ID <: BSplineInterpolationDimension, T} <: AbstractVector{T}
     itp_dim::ID
     i::Int
     derivative_order_eval::Int
     function BasisFunctionVector(itp_dim, i, derivative_order_eval)
         n_basis_functions = get_n_basis_functions(itp_dim)
-        @assert 1≤i≤n_basis_functions "The itp_dim has only $n_basis_functions basis functions, got $i."
-        @assert 0≤derivative_order_eval≤itp_dim.max_derivative_order_eval "The itp_dim has max_derivative_order_eval = $(itp_dim.max_derivative_order_eval), got $derivative_order_eval."
-        new{typeof(itp_dim), eltype(itp_dim.basis_function_eval)}(
+        @assert 1 ≤ i ≤ n_basis_functions "The itp_dim has only $n_basis_functions basis functions, got $i."
+        @assert 0 ≤ derivative_order_eval ≤ itp_dim.max_derivative_order_eval "The itp_dim has max_derivative_order_eval = $(itp_dim.max_derivative_order_eval), got $derivative_order_eval."
+        return new{typeof(itp_dim), eltype(itp_dim.basis_function_eval)}(
             itp_dim, i, derivative_order_eval
         )
     end
@@ -187,7 +199,7 @@ function Base.getindex(bfv::BasisFunctionVector, j)
     (; itp_dim, i, derivative_order_eval) = bfv
     (; basis_function_eval, idx_eval, degree) = itp_dim
     idx = idx_eval[j]
-    if i ≤ idx ≤ i + degree
+    return if i ≤ idx ≤ i + degree
         basis_function_eval[j, degree + i - idx + 1, derivative_order_eval + 1]
     else
         zero(eltype(basis_function_eval))
@@ -195,7 +207,7 @@ function Base.getindex(bfv::BasisFunctionVector, j)
 end
 
 function get_n_basis_functions(itp_dim::BSplineInterpolationDimension)
-    length(itp_dim.knots_all) - itp_dim.degree - 1
+    return length(itp_dim.knots_all) - itp_dim.degree - 1
 end
 
 """

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -12,23 +12,29 @@ using Test
 
     itp_linear = NDInterpolation(
         u_linear,
-        (LinearInterpolationDimension(t1; t_eval = t1_eval),
-            LinearInterpolationDimension(t2; t_eval = t2_eval))
+        (
+            LinearInterpolationDimension(t1; t_eval = t1_eval),
+            LinearInterpolationDimension(t2; t_eval = t2_eval),
+        )
     )
 
     # B-spline setup
     u_bspline = fill(2.0, 6, 7)
     itp_bspline = NDInterpolation(
         u_bspline,
-        (BSplineInterpolationDimension(t1, 2; t_eval = t1_eval, max_derivative_order_eval = 1),
-            BSplineInterpolationDimension(t2, 3; t_eval = t2_eval, max_derivative_order_eval = 1))
+        (
+            BSplineInterpolationDimension(t1, 2; t_eval = t1_eval, max_derivative_order_eval = 1),
+            BSplineInterpolationDimension(t2, 3; t_eval = t2_eval, max_derivative_order_eval = 1),
+        )
     )
 
     # Constant interpolation setup
     itp_const = NDInterpolation(
         u_linear,
-        (ConstantInterpolationDimension(t1; t_eval = t1_eval),
-            ConstantInterpolationDimension(t2; t_eval = t2_eval))
+        (
+            ConstantInterpolationDimension(t1; t_eval = t1_eval),
+            ConstantInterpolationDimension(t2; t_eval = t2_eval),
+        )
     )
 
     # NURBS setup
@@ -38,52 +44,76 @@ using Test
     u_nurbs = Float64[1 0; 1 1; 0 1; -1 1; -1 0; -1 -1; 0 -1; 1 -1; 1 0]
     weights = ones(9)
     weights[2:2:end] ./= sqrt(2)
-    itp_nurbs = NDInterpolation(u_nurbs,
-        (BSplineInterpolationDimension(t_nurbs, 2;
-            multiplicities = multiplicities, t_eval = t_eval_nurbs),);
-        cache = NURBSWeights(weights))
+    itp_nurbs = NDInterpolation(
+        u_nurbs,
+        (
+            BSplineInterpolationDimension(
+                t_nurbs, 2;
+                multiplicities = multiplicities, t_eval = t_eval_nurbs
+            ),
+        );
+        cache = NURBSWeights(weights)
+    )
 
     @testset "Linear interpolation" begin
-        rep = JET.report_call(eval_unstructured, (typeof(itp_linear),);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_call(
+            eval_unstructured, (typeof(itp_linear),);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
 
-        rep = JET.report_call(eval_grid, (typeof(itp_linear),);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_call(
+            eval_grid, (typeof(itp_linear),);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
 
-        rep = JET.report_call(itp_linear, (Tuple{Float64, Float64},);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_call(
+            itp_linear, (Tuple{Float64, Float64},);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
     end
 
     @testset "B-spline interpolation" begin
-        rep = JET.report_call(eval_unstructured, (typeof(itp_bspline),);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_call(
+            eval_unstructured, (typeof(itp_bspline),);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
 
-        rep = JET.report_call(eval_grid, (typeof(itp_bspline),);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_call(
+            eval_grid, (typeof(itp_bspline),);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
     end
 
     @testset "Constant interpolation" begin
-        rep = JET.report_call(eval_unstructured, (typeof(itp_const),);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_call(
+            eval_unstructured, (typeof(itp_const),);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
 
-        rep = JET.report_call(eval_grid, (typeof(itp_const),);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_call(
+            eval_grid, (typeof(itp_const),);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
     end
 
     @testset "NURBS interpolation" begin
-        rep = JET.report_call(eval_unstructured, (typeof(itp_nurbs),);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_call(
+            eval_unstructured, (typeof(itp_nurbs),);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
 
-        rep = JET.report_call(eval_grid, (typeof(itp_nurbs),);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_call(
+            eval_grid, (typeof(itp_nurbs),);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
     end
 end
@@ -98,30 +128,40 @@ end
 
     itp_linear = NDInterpolation(
         u_linear,
-        (LinearInterpolationDimension(t1; t_eval = t1_eval),
-            LinearInterpolationDimension(t2; t_eval = t2_eval))
+        (
+            LinearInterpolationDimension(t1; t_eval = t1_eval),
+            LinearInterpolationDimension(t2; t_eval = t2_eval),
+        )
     )
 
     # Constant interpolation setup
     itp_const = NDInterpolation(
         u_linear,
-        (ConstantInterpolationDimension(t1; t_eval = t1_eval),
-            ConstantInterpolationDimension(t2; t_eval = t2_eval))
+        (
+            ConstantInterpolationDimension(t1; t_eval = t1_eval),
+            ConstantInterpolationDimension(t2; t_eval = t2_eval),
+        )
     )
 
     @testset "Linear interpolation optimization" begin
-        rep = JET.report_opt(eval_unstructured, (typeof(itp_linear),);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_opt(
+            eval_unstructured, (typeof(itp_linear),);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
 
-        rep = JET.report_opt(itp_linear, (Tuple{Float64, Float64},);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_opt(
+            itp_linear, (Tuple{Float64, Float64},);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
     end
 
     @testset "Constant interpolation optimization" begin
-        rep = JET.report_opt(eval_unstructured, (typeof(itp_const),);
-            target_modules = (DataInterpolationsND,))
+        rep = JET.report_opt(
+            eval_unstructured, (typeof(itp_const),);
+            target_modules = (DataInterpolationsND,)
+        )
         @test length(JET.get_reports(rep)) == 0
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ const GROUP = get(ENV, "GROUP", "All")
 function activate_gpu_env()
     Pkg.activate("gpu")
     Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
-    Pkg.instantiate()
+    return Pkg.instantiate()
 end
 
 if GROUP == "All" || GROUP == "Core"

--- a/test/test_datainterpolations_comparison.jl
+++ b/test/test_datainterpolations_comparison.jl
@@ -6,7 +6,7 @@ isapprox_or_nan(v1, v2) = (v1 ≈ v2) || (all(isnan, v1) && all(isnan, v2))
 function interpolation_comparison(
         itp_dim_type::Type{<:DataInterpolationsND.AbstractInterpolationDimension},
         itp_type::Type{<:DataInterpolations.AbstractInterpolation}
-)
+    )
     t = [0.0, 0.2, 0.5, 0.7, 0.9, 1.1]
     u = [1.5, -5.3, 0.5, 3.3, 3.6, 1.0]
 
@@ -27,13 +27,13 @@ function interpolation_comparison(
 
     # Boundary points
     t_eval = [first(t), last(t)]
-    @test itp_DI(t_eval) ≈ itp_NDI.(t_eval)
+    return @test itp_DI(t_eval) ≈ itp_NDI.(t_eval)
 end
 
 function interpolation_derivative_comparison(
         itp_dim_type::Type{<:DataInterpolationsND.AbstractInterpolationDimension},
         itp_type::Type{<:DataInterpolations.AbstractInterpolation}
-)
+    )
     t = [0.0, 0.2, 0.5, 0.7, 0.9, 1.1]
     u = [1.5, -5.3, 0.5, 3.3, 3.6, 1.0]
 
@@ -46,7 +46,7 @@ function interpolation_derivative_comparison(
     for i in 1:(n - 1)
         t_eval = range(t[i], t[i + 1]; length = 25)[2:24]
         @test DataInterpolations.derivative.(Ref(itp_DI), t_eval) ≈
-              itp_NDI.(t_eval; derivative_orders = (1,))
+            itp_NDI.(t_eval; derivative_orders = (1,))
     end
 
     # Interior data points
@@ -58,16 +58,16 @@ function interpolation_derivative_comparison(
 
     # Boundary points
     t_eval = [first(t), last(t)]
-    @test isapprox_or_nan(
+    return @test isapprox_or_nan(
         DataInterpolations.derivative.(Ref(itp_DI), t_eval),
         itp_NDI.(t_eval; derivative_orders = (1,))
     )
 end
 
 for (itp_dim_type, itp_type) in (
-    (LinearInterpolationDimension, LinearInterpolation),
-    (ConstantInterpolationDimension, ConstantInterpolation)
-)
+        (LinearInterpolationDimension, LinearInterpolation),
+        (ConstantInterpolationDimension, ConstantInterpolation),
+    )
     @testset "$itp_type" begin
         interpolation_comparison(itp_dim_type, itp_type)
         interpolation_derivative_comparison(itp_dim_type, itp_type)

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -3,18 +3,19 @@ using ForwardDiff
 using Random
 
 function test_deriv_10(itp, t)
-    @test itp(t; derivative_orders = (1, 0)) ≈
-          ForwardDiff.derivative(t₁ -> itp(t₁, t[2]), t[1])
+    return @test itp(t; derivative_orders = (1, 0)) ≈
+        ForwardDiff.derivative(t₁ -> itp(t₁, t[2]), t[1])
 end
 
 function test_deriv_01(itp, t)
-    @test itp(t; derivative_orders = (0, 1)) ≈
-          ForwardDiff.derivative(t₂ -> itp(t[1], t₂), t[2])
+    return @test itp(t; derivative_orders = (0, 1)) ≈
+        ForwardDiff.derivative(t₂ -> itp(t[1], t₂), t[2])
 end
 
 function test_deriv_11(itp, t)
-    @test itp(t; derivative_orders = (1, 1)) ≈
-          ForwardDiff.derivative(t₂ -> ForwardDiff.derivative(
+    return @test itp(t; derivative_orders = (1, 1)) ≈
+        ForwardDiff.derivative(
+        t₂ -> ForwardDiff.derivative(
             t₁ -> itp(t₁, t₂), t[1]
         ),
         t[2]
@@ -34,11 +35,13 @@ function test_derivatives(itp::NDInterpolation{2})
 
     # Derivatives between data points
     for t in Iterators.product(
-        t1[1:(end - 1)] + diff(t1) / 2, t2[1:(end - 1)] + diff(t2) / 2)
+            t1[1:(end - 1)] + diff(t1) / 2, t2[1:(end - 1)] + diff(t2) / 2
+        )
         test_deriv_10(itp, t)
         test_deriv_01(itp, t)
         test_deriv_11(itp, t)
     end
+    return
 end
 
 @testset "Linear Interpolation" begin
@@ -48,7 +51,7 @@ end
     u = rand(5, 5)
     itp_dims = (
         LinearInterpolationDimension(t1),
-        LinearInterpolationDimension(t2)
+        LinearInterpolationDimension(t2),
     )
     itp = NDInterpolation(u, itp_dims)
     test_derivatives(itp)
@@ -61,7 +64,7 @@ end
     u = rand(6, 6)
     itp_dims = (
         BSplineInterpolationDimension(t1, 2),
-        BSplineInterpolationDimension(t2, 2)
+        BSplineInterpolationDimension(t2, 2),
     )
     itp = NDInterpolation(u, itp_dims)
     test_derivatives(itp)
@@ -69,7 +72,7 @@ end
     u = rand(9, 9)
     itp_dims = (
         BSplineInterpolationDimension(t1, 5),
-        BSplineInterpolationDimension(t2, 5)
+        BSplineInterpolationDimension(t2, 5),
     )
     itp = NDInterpolation(u, itp_dims)
     test_derivatives(itp)

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -36,7 +36,8 @@ using Test
         @test eltype(itp_dim.knots_all) == BigFloat
 
         itp_dim_eval = BSplineInterpolationDimension(
-            t, 2; t_eval = t_eval, max_derivative_order_eval = 1)
+            t, 2; t_eval = t_eval, max_derivative_order_eval = 1
+        )
         @test eltype(itp_dim_eval.t_eval) == BigFloat
         @test eltype(itp_dim_eval.basis_function_eval) <: BigFloat
     end
@@ -48,7 +49,7 @@ using Test
 
         itp_dims = (
             LinearInterpolationDimension(t1),
-            LinearInterpolationDimension(t2)
+            LinearInterpolationDimension(t2),
         )
         itp = NDInterpolation(u, itp_dims)
 
@@ -68,7 +69,7 @@ using Test
 
         itp_dims = (
             ConstantInterpolationDimension(t1),
-            ConstantInterpolationDimension(t2)
+            ConstantInterpolationDimension(t2),
         )
         itp = NDInterpolation(u, itp_dims)
 
@@ -84,7 +85,7 @@ using Test
 
         itp_dims = (
             BSplineInterpolationDimension(t, 2),
-            BSplineInterpolationDimension(t, 2)
+            BSplineInterpolationDimension(t, 2),
         )
         itp = NDInterpolation(u, itp_dims)
 
@@ -114,7 +115,7 @@ using Test
 
         itp_dims = (
             LinearInterpolationDimension(t1; t_eval = t1_eval),
-            LinearInterpolationDimension(t2; t_eval = t2_eval)
+            LinearInterpolationDimension(t2; t_eval = t2_eval),
         )
         itp = NDInterpolation(u, itp_dims)
 
@@ -130,7 +131,7 @@ using Test
 
         itp_dims = (
             LinearInterpolationDimension(t1),
-            LinearInterpolationDimension(t2)
+            LinearInterpolationDimension(t2),
         )
         itp = NDInterpolation(u, itp_dims)
 
@@ -148,7 +149,7 @@ end
 
         itp_dims = (
             LinearInterpolationDimension(t1),
-            LinearInterpolationDimension(t2)
+            LinearInterpolationDimension(t2),
         )
         itp = NDInterpolation(u, itp_dims)
 
@@ -170,7 +171,7 @@ end
 
         itp_dims = (
             LinearInterpolationDimension(t1; t_eval = t1_eval),
-            LinearInterpolationDimension(t2; t_eval = t2_eval)
+            LinearInterpolationDimension(t2; t_eval = t2_eval),
         )
         itp = NDInterpolation(u, itp_dims)
 
@@ -187,7 +188,7 @@ end
 
         itp_dims = (
             LinearInterpolationDimension(t1),
-            LinearInterpolationDimension(t2)
+            LinearInterpolationDimension(t2),
         )
         itp = NDInterpolation(u, itp_dims)
 

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -4,7 +4,8 @@ using Random
 
 function test_globally_constant(
         ID::Type{<:AbstractInterpolationDimension}; args1 = (), args2 = (), kwargs1 = (),
-        kwargs2 = (), cache = EmptyCache(), test_derivatives = true)
+        kwargs2 = (), cache = EmptyCache(), test_derivatives = true
+    )
     t1 = [-3.14, 1.0, 3.0, 7.6, 12.8]
     t2 = [-2.71, 1.41, 12.76, 50.2, 120.0]
 
@@ -17,30 +18,34 @@ function test_globally_constant(
     # Evaluation in data points
     itp_dims = (
         ID(t1, args1...; t_eval = t1, kwargs1...),
-        ID(t2, args2...; t_eval = t2, kwargs2...)
+        ID(t2, args2...; t_eval = t2, kwargs2...),
     )
 
     itp = NDInterpolation(u, itp_dims; cache)
-    @test all(x -> isapprox(x, 2.0; atol = 1e-10), eval_grid(itp))
+    @test all(x -> isapprox(x, 2.0; atol = 1.0e-10), eval_grid(itp))
     if test_derivatives
         @test all(
-            x -> isapprox(x, 0.0; atol = 1e-10), eval_grid(itp, derivative_orders = (1, 0)))
+            x -> isapprox(x, 0.0; atol = 1.0e-10), eval_grid(itp, derivative_orders = (1, 0))
+        )
         @test all(
-            x -> isapprox(x, 0.0; atol = 1e-10), eval_grid(itp, derivative_orders = (0, 1)))
+            x -> isapprox(x, 0.0; atol = 1.0e-10), eval_grid(itp, derivative_orders = (0, 1))
+        )
     end
 
     # Evaluation between data points
     itp_dims = (
         ID(t1, args1...; t_eval = t1[1:(end - 1)] + diff(t1) / 2, kwargs1...),
-        ID(t2, args2...; t_eval = t2[1:(end - 1)] + diff(t2) / 2, kwargs2...)
+        ID(t2, args2...; t_eval = t2[1:(end - 1)] + diff(t2) / 2, kwargs2...),
     )
     itp = NDInterpolation(u, itp_dims)
-    @test all(x -> isapprox(x, 2.0; atol = 1e-10), eval_grid(itp))
-    if test_derivatives
+    @test all(x -> isapprox(x, 2.0; atol = 1.0e-10), eval_grid(itp))
+    return if test_derivatives
         @test all(
-            x -> isapprox(x, 0.0; atol = 1e-10), eval_grid(itp, derivative_orders = (1, 0)))
+            x -> isapprox(x, 0.0; atol = 1.0e-10), eval_grid(itp, derivative_orders = (1, 0))
+        )
         @test all(
-            x -> isapprox(x, 0.0; atol = 1e-10), eval_grid(itp, derivative_orders = (0, 1)))
+            x -> isapprox(x, 0.0; atol = 1.0e-10), eval_grid(itp, derivative_orders = (0, 1))
+        )
     end
 end
 
@@ -56,6 +61,7 @@ function test_analytic(itp::NDInterpolation{N_in}, f) where {N_in}
     for t in Iterators.product(ts_...)
         @test itp(t) ≈ f(t...)
     end
+    return
 end
 
 @testset "Linear Interpolation" begin
@@ -69,7 +75,7 @@ end
 
     itp_dims = (
         LinearInterpolationDimension(t1),
-        LinearInterpolationDimension(t2)
+        LinearInterpolationDimension(t2),
     )
     u = f.(t1, t2')
     itp = NDInterpolation(u, itp_dims)
@@ -117,15 +123,17 @@ end
     multiplicities = [3, 2, 2, 2, 3]
 
     # Control points
-    u = Float64[1 0;
-                1 1;
-                0 1;
-                -1 1;
-                -1 0;
-                -1 -1;
-                0 -1;
-                1 -1;
-                1 0]
+    u = Float64[
+        1 0;
+        1 1;
+        0 1;
+        -1 1;
+        -1 0;
+        -1 -1;
+        0 -1;
+        1 -1;
+        1 0
+    ]
 
     # Weights
     weights = ones(9)

--- a/test/test_symbolics_ext.jl
+++ b/test/test_symbolics_ext.jl
@@ -9,7 +9,7 @@ t2 = cumsum(rand(7))
 
 interpolation_dimensions = (
     LinearInterpolationDimension(t1),
-    LinearInterpolationDimension(t2)
+    LinearInterpolationDimension(t2),
 )
 
 u = rand(5, 7, 2)
@@ -23,11 +23,13 @@ interp = NDInterpolation(u, interpolation_dimensions)
     @test size(ex) == (2,)
     @test SU.symtype(unwrap(ex)) == Vector{Real}
 
-    res = eval(quote
-        let x = 0.4, y = 0.8
-            $(SU.Code.toexpr(ex))
+    res = eval(
+        quote
+            let x = 0.4, y = 0.8
+                $(SU.Code.toexpr(ex))
+            end
         end
-    end)
+    )
     @test res ≈ interp(0.4, 0.8)
 
     ex = interp(unwrap(x), unwrap(y))
@@ -39,20 +41,24 @@ end
     der = Symbolics.derivative(ex[1], x)
     @test size(der) == ()
     @test SU.symtype(unwrap(der)) == Real
-    res = eval(quote
-        let x = 0.4, y = 0.8
-            $(SU.Code.toexpr(der))
+    res = eval(
+        quote
+            let x = 0.4, y = 0.8
+                $(SU.Code.toexpr(der))
+            end
         end
-    end)
+    )
     @test res ≈ interp(0.4, 0.8; derivative_orders = (1, 0))[1]
 
     der = Symbolics.derivative(ex[1], y)
     @test size(der) == ()
     @test SU.symtype(unwrap(der)) == Real
-    res = eval(quote
-        let x = 0.4, y = 0.8
-            $(SU.Code.toexpr(der))
+    res = eval(
+        quote
+            let x = 0.4, y = 0.8
+                $(SU.Code.toexpr(der))
+            end
         end
-    end)
+    )
     @test res ≈ interp(0.4, 0.8; derivative_orders = (0, 1))[1]
 end


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)