### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "julia"
+    directories:
+      - "/"
+      - "/docs"
+      - "/test/gpu"
+      - "/test/qa"
+    schedule:
+      interval: "daily"
+    groups:
+      all-julia-packages:
+        patterns:
+          - "*"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,26 @@
+name: "Downgrade"
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch || github.ref != 'refs/tags/v*' }}
+
+jobs:
+  downgrade:
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,9 @@
+name: "Spell Check"
+
+on: [pull_request]
+
+jobs:
+  spellcheck:
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+# "ND" stands for "N-Dimensional" throughout this package (the package name
+# DataInterpolationsND, the NDInterpolation type, etc.); it is not a typo for "AND".
+[default.extend-words]
+ND = "ND"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts/extends this repo's CI to use the centralized SciML/.github reusable workflows (pinned `@v1`) for everything, matching the Sundials.jl end-state. Every caller passes `secrets: "inherit"`.

## Converted (inline -> central caller)
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `SciML/.github/.github/workflows/runic.yml@v1`. Existing `name:`/`on:` preserved.

## Added (new central callers / config)
- **SpellCheck.yml**: new `spellcheck.yml@v1` caller (crate-ci/typos). Added `_typos.toml` whitelisting the word `ND` (stands for N-Dimensional: the package name `DataInterpolationsND`, the `NDInterpolation` type, etc.) which typos otherwise flags as a misspelling of `AND`. No prose or identifiers were edited; this is purely a domain false-positive suppression.
- **Downgrade.yml**: new `downgrade.yml@v1` caller (`julia-version: "lts"`, `skip: "Pkg,TOML"`).
- **.github/dependabot.yml**: new file — `github-actions` (`/`, weekly) and `julia` (daily, group `all-julia-packages: ["*"]`) over `/`, `/docs`, `/test/gpu`, `/test/qa` (the dirs with a Project.toml).

## Already centralized (unchanged)
- **Tests.yml** and **documentation.yml** were already `tests.yml@v1` / `documentation.yml@v1` callers with `secrets: "inherit"`. Their exact version×group×os matrix is untouched.

## Left as-is
- **GPU.yml**: specialized self-hosted GPU test job (`[self-hosted, Linux, X64, gpu]`); there is no central GPU caller, so it is unchanged.
- **TagBot.yml**: unchanged.

## Verification
- `typos .` exits 0 with the new `_typos.toml`.
- Runic produced no changes (repo was already Runic-clean from the prior inline check), so no formatting commit was needed.
- All changed `.github/workflows/*.yml` and `dependabot.yml` pass `python yaml.safe_load`.

## Heads up
Check names will change for the converted/added checks (e.g. Runic now runs via the reusable workflow). **Branch-protection required-status-check names may need updating** accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)