### PR TITLE
Run CI test groups on ubuntu only (drop the os matrix)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,6 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
-os = ["ubuntu-latest", "macos-latest", "windows-latest"]
 
 [QA]
 versions = ["lts", "1"]

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -4,4 +4,3 @@ os = ["ubuntu-latest", "macos-latest", "windows-latest"]
 
 [QA]
 versions = ["lts", "1"]
-os = ["ubuntu-latest", "macos-latest", "windows-latest"]


### PR DESCRIPTION
The QA test group (Aqua/JET) was running on the full multi-OS matrix (ubuntu, macos, windows). Those checks are platform-independent, so the windows/macos QA jobs were wasted CI with no added coverage.

Extended per review feedback: the `os` axis is now dropped from **all** groups (Core included). This is a pure-Julia package — no platform-dependent code paths, no artifacts, no binary deps beyond stdlib — so per-OS CPU test runs add cost without coverage. With the `os` key absent, the grouped-tests workflow defaults each job to `ubuntu-latest`.

Two additional data points in favor:
- The windows grouped jobs currently don't even run their declared group: the group-env step in SciML/.github `tests.yml` lacks `shell: bash`, so `GROUP` is never set on windows and every windows job silently runs the default group (fix: SciML/.github#81). Their green checkmarks were not real coverage.
- GPU coverage is unaffected — it's a separate workflow on self-hosted runners.

Restoring an OS for any group later is one line in `test/test_groups.toml`.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)