### PR TITLE
Port Symbolics extension to the Symbolics v7 APIs

### DIFF
--- a/ext/DataInterpolationsNDSymbolicsExt.jl
+++ b/ext/DataInterpolationsNDSymbolicsExt.jl
@@ -3,7 +3,7 @@ module DataInterpolationsNDSymbolicsExt
 import DataInterpolationsND
 using DataInterpolationsND: NDInterpolation
 using Symbolics
-using Symbolics: Num, unwrap
+using Symbolics: Num, unwrap, @register_derivative
 import SymbolicUtils
 
 struct DifferentiatedNDInterpolation{N_in, N_out, I <: NDInterpolation{N_in, N_out}}
@@ -18,33 +18,27 @@ end
 Base.nameof(::NDInterpolation) = :NDInterpolation
 Base.nameof(::DifferentiatedNDInterpolation) = :DifferentiatedNDInterpolation
 
-for symT in [Num, SymbolicUtils.BasicSymbolic{<:Real}]
-    @eval function (interp::NDInterpolation{N_in, N_out})(
-            t::Vararg{
-                $symT, N_in,
-            }
-        ) where {N_in, N_out}
-        if $(symT === Num)
-            t = unwrap.(t)
-        end
-        res = if N_out == 0
-            SymbolicUtils.term(interp, t...; type = Real)
-        else
-            Symbolics.array_term(
-                interp, t...; eltype = Real, container_type = Array, ndims = N_out,
-                size = DataInterpolationsND.get_output_size(interp)
-            )
-        end
-        if $(symT === Num)
-            if N_out == 0
-                res = Num(res)
-            else
-                res = Symbolics.Arr{Num, N_out}(res)
-            end
-        end
-        return res
+const SymbolicNDInterpolation = Union{
+    NDInterpolation{N_in, N_out},
+    DifferentiatedNDInterpolation{N_in, N_out},
+} where {N_in, N_out}
+
+base_interp(interp::NDInterpolation) = interp
+base_interp(interp::DifferentiatedNDInterpolation) = interp.interp
+
+function output_shape(interp, ::Val{N_out}) where {N_out}
+    return if N_out == 0
+        SymbolicUtils.ShapeVecT()
+    else
+        sz = DataInterpolationsND.get_output_size(base_interp(interp))
+        SymbolicUtils.ShapeVecT(map(n -> 1:n, sz))
     end
-    @eval function (interp::DifferentiatedNDInterpolation{N_in, N_out})(
+end
+
+for interpT in [NDInterpolation, DifferentiatedNDInterpolation],
+        symT in [Num, Symbolics.SymbolicT]
+
+    @eval function (interp::$interpT{N_in, N_out})(
             t::Vararg{
                 $symT, N_in,
             }
@@ -52,14 +46,11 @@ for symT in [Num, SymbolicUtils.BasicSymbolic{<:Real}]
         if $(symT === Num)
             t = unwrap.(t)
         end
-        res = if N_out == 0
-            SymbolicUtils.term(interp, t...; type = Real)
-        else
-            Symbolics.array_term(
-                interp, t...; eltype = Real, container_type = Array, ndims = N_out,
-                size = DataInterpolationsND.get_output_size(interp.interp)
-            )
-        end
+        res = SymbolicUtils.term(
+            interp, t...;
+            type = N_out == 0 ? Real : Array{Real, N_out},
+            shape = output_shape(interp, Val(N_out))
+        )
         if $(symT === Num)
             if N_out == 0
                 res = Num(res)
@@ -70,30 +61,28 @@ for symT in [Num, SymbolicUtils.BasicSymbolic{<:Real}]
         return res
     end
 end
-function SymbolicUtils.promote_symtype(::NDInterpolation{N_in, N_out}, ::Vararg) where {
-        N_in, N_out,
-    }
+
+function SymbolicUtils.promote_symtype(
+        ::SymbolicNDInterpolation{N_in, N_out}, ::Vararg
+    ) where {N_in, N_out}
     return N_out == 0 ? Real : Array{Real, N_out}
 end
 
-function Symbolics.derivative(
-        interp::NDInterpolation{N_in, N_out},
-        args::NTuple{N_in, Any}, ::Val{I}
-    ) where {N_in, N_out, I}
-    @assert I <= N_in
-    orders = ntuple(Int ∘ isequal(I), Val{N_in}())
-    dinterp = DifferentiatedNDInterpolation{N_in, N_out, typeof(interp)}(interp, orders)
-    return dinterp(args...)
+function SymbolicUtils.promote_shape(
+        interp::SymbolicNDInterpolation{N_in, N_out}, ::SymbolicUtils.ShapeT...
+    ) where {N_in, N_out}
+    return output_shape(interp, Val(N_out))
 end
 
-function Symbolics.derivative(
-        interp::DifferentiatedNDInterpolation{N_in, N_out},
-        args::NTuple{N_in, Any}, ::Val{I}
-    ) where {N_in, N_out, I}
-    @assert I <= N_in
-    orders_offset = ntuple(Int ∘ isequal(I), Val{N_in}())
+@register_derivative (interp::NDInterpolation)(args...) I begin
+    orders = ntuple(Int ∘ isequal(I), Val{Nargs}())
+    DifferentiatedNDInterpolation(interp, orders)(args...)
+end
+
+@register_derivative (interp::DifferentiatedNDInterpolation)(args...) I begin
+    orders_offset = ntuple(Int ∘ isequal(I), Val{Nargs}())
     orders = interp.derivative_orders .+ orders_offset
-    return typeof(interp)(interp.interp, orders)(args...)
+    typeof(interp)(interp.interp, orders)(args...)
 end
 
 end # module

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,5 +1,9 @@
 [Core]
 versions = ["lts", "1", "pre"]
 
+[Extensions]
+versions = ["lts", "1", "pre"]
+os = ["ubuntu-latest", "macos-latest", "windows-latest"]
+
 [QA]
 versions = ["lts", "1"]

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -3,7 +3,6 @@ versions = ["lts", "1", "pre"]
 
 [Extensions]
 versions = ["lts", "1", "pre"]
-os = ["ubuntu-latest", "macos-latest", "windows-latest"]
 
 [QA]
 versions = ["lts", "1"]

--- a/test/test_symbolics_ext.jl
+++ b/test/test_symbolics_ext.jl
@@ -33,7 +33,7 @@ interp = NDInterpolation(u, interpolation_dimensions)
     @test res ≈ interp(0.4, 0.8)
 
     ex = interp(unwrap(x), unwrap(y))
-    @test ex isa SU.BasicSymbolic{Vector{Real}}
+    @test SU.symtype(ex) == Vector{Real}
 end
 
 @testset "Differentiation" begin
@@ -61,4 +61,69 @@ end
         end
     )
     @test res ≈ interp(0.4, 0.8; derivative_orders = (0, 1))[1]
+end
+
+# Scalar output (N_out == 0), e.g. a 2D table of scalars as used with
+# ModelingToolkit callable parameters (issue #69)
+u_scalar = rand(5, 7)
+interp_scalar = NDInterpolation(u_scalar, interpolation_dimensions)
+
+@testset "Scalar output basics" begin
+    ex = interp_scalar(x, y)
+    @test ex isa Num
+    @test SU.symtype(unwrap(ex)) == Real
+    @test !SU.is_array_shape(SU.shape(unwrap(ex)))
+
+    res = eval(
+        quote
+            let x = 0.4, y = 0.8
+                $(SU.Code.toexpr(unwrap(ex)))
+            end
+        end
+    )
+    @test res ≈ interp_scalar(0.4, 0.8)
+end
+
+@testset "Scalar output differentiation" begin
+    ex = interp_scalar(x, y)
+
+    for (var, orders) in ((x, (1, 0)), (y, (0, 1)))
+        der = expand_derivatives(Differential(var)(ex))
+        @test SU.symtype(unwrap(der)) == Real
+        # the derivative must be fully expanded, with no `Differential` left over
+        @test !Symbolics.hasderiv(unwrap(der))
+        res = eval(
+            quote
+                let x = 0.4, y = 0.8
+                    $(SU.Code.toexpr(unwrap(der)))
+                end
+            end
+        )
+        @test res ≈ interp_scalar(0.4, 0.8; derivative_orders = orders)
+    end
+
+    # chain rule through both arguments
+    @variables s
+    ex_s = interp_scalar(2.0 * s, s)
+    der = expand_derivatives(Differential(s)(ex_s))
+    res = eval(
+        quote
+            let s = 0.4
+                $(SU.Code.toexpr(unwrap(der)))
+            end
+        end
+    )
+    @test res ≈ 2.0 * interp_scalar(0.8, 0.4; derivative_orders = (1, 0)) +
+        interp_scalar(0.8, 0.4; derivative_orders = (0, 1))
+
+    # second derivatives differentiate the `DifferentiatedNDInterpolation`
+    der2 = expand_derivatives(Differential(y)(Differential(x)(ex)))
+    res = eval(
+        quote
+            let x = 0.4, y = 0.8
+                $(SU.Code.toexpr(unwrap(der2)))
+            end
+        end
+    )
+    @test res ≈ interp_scalar(0.4, 0.8; derivative_orders = (1, 1))
 end


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Investigation of #69 revealed the Symbolics extension has been entirely non-functional on Symbolics v7 — which is the only version the compat allows — because it still uses the v6 extension APIs:

1. **`Symbolics.array_term` does not exist in any Symbolics v7 release.** Symbolically calling an array-output (`N_out >= 1`) interpolation throws `UndefVarError: array_term not defined`.
2. **Scalar-output terms had `Unknown` shape.** `SymbolicUtils.term(interp, t...; type = Real)` leaves `shape = Unknown(-1)`, which `expand_derivatives` rejects with `Differentiation with array expressions is not yet supported`. SymbolicUtils v4 needs `promote_shape` (or an explicit `shape`) for non-builtin callables.
3. **The derivative registrations were dead code.** The `Symbolics.derivative(op, args, ::Val{I})` overload API was removed in Symbolics v7 in favor of `@register_derivative`/`derivative_rule` (the same migration DataInterpolations.jl did in its Symbolics ext behind a `pkgversion(Symbolics) >= v"7"` check). Defining methods on the old function does nothing, so derivatives of interpolation terms were left as unexpanded `Differential` operators.

**Why CI never caught this:** `test/runtests.jl` has an `Extensions` group containing `test_symbolics_ext.jl`, but `test/test_groups.toml` only declares `Core` and `QA`, so the extension tests never ran on CI. (Locally, on current main with Symbolics v7.26, `test_symbolics_ext.jl` errors immediately at `interp(x, y)`.)

### Changes
- Build terms with `SymbolicUtils.term` with explicit `type` and `shape`, and define `SymbolicUtils.promote_shape` alongside `promote_symtype` for both `NDInterpolation` and `DifferentiatedNDInterpolation`.
- Register derivatives with `@register_derivative`; partial derivatives are still represented by `DifferentiatedNDInterpolation` so arbitrary mixed orders compose.
- Add the `Extensions` group to `test_groups.toml` so these tests actually run on CI.
- Extend tests: scalar-output (`N_out == 0`) interpolations (the #69 use case — previously untested), full `expand_derivatives` chain rule through both arguments, second/mixed derivatives, and numeric evaluation of every generated expression. Also fixed an `ex isa BasicSymbolic{Vector{Real}}` assertion that is invalid under SymbolicUtils v4 (the type parameter is now the variant, not the symtype).

All APIs used (`@register_derivative`, `Symbolics.SymbolicT`, `SymbolicUtils.ShapeVecT`) exist since Symbolics v7.0.0, so no compat change is needed.

### What this does and does not fix for #69
With this PR, **directly embedding** `NDInterpolation` objects in MTK equations works end-to-end: the #69 MWE rewritten with direct embedding compiles via `mtkcompile` (9-equation fully determined system) and solves successfully with `Rodas5P` (verified locally).

The original MWE uses MTK **callable parameters** (`(itp::NDInterpolation)(..)`), and that form still fails: in the symbolic expression the operation is the symbolic stand-in for the parameter (symtype `FnType{Tuple, Real, NDInterpolation}`), not an `NDInterpolation` instance, so no instance-dispatched derivative rule can ever fire and `expand_derivatives` leaves `Differential(p(t))(itp(p(t), T(t)))` behind, which `validate_operator` then rejects. That gap is upstream (Symbolics needs a hook to dispatch derivative rules on the FnType's callable type) and affects DataInterpolations.jl 1-D the same way whenever a callable parameter is called with an unknown rather than `t` (its `ODEProblem` construction fails at the initialization system even though `mtkcompile` happens to pass). I am filing that separately upstream.

### Local test output
```
GROUP=Extensions Pkg.test():
Test Summary:       | Pass  Total   Time
Symbolics Extension |   23     23  44.3s

GROUP=Core Pkg.test():
Interpolations |  206    206
Derivatives    |  369    369
DataInterpolations |   28     28
Interface      |   21     21
```
Runic.jl run on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)