### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,16 +1,13 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DataInterpolationsND = "4f1ef021-621a-47a5-ac8a-95402a2d1ea8"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
 DataInterpolationsND = "0.1"
-ExplicitImports = "1.14.0"
 JET = "0.9, 0.10, 0.11.2"
-SafeTestsets = "0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
+Test = "1.10"

--- a/test/qa/aqua.jl
+++ b/test/qa/aqua.jl
@@ -1,6 +1,0 @@
-using Aqua
-using DataInterpolationsND
-
-@testset "Aqua" begin
-    Aqua.test_all(DataInterpolationsND)
-end

--- a/test/qa/explicit_imports.jl
+++ b/test/qa/explicit_imports.jl
@@ -1,8 +1,0 @@
-using ExplicitImports
-using DataInterpolationsND
-using Test
-
-@testset "ExplicitImports" begin
-    @test check_no_implicit_imports(DataInterpolationsND) === nothing
-    @test check_no_stale_explicit_imports(DataInterpolationsND) === nothing
-end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,15 @@
+using SciMLTesting, DataInterpolationsND, Test
+
+run_qa(
+    DataInterpolationsND; explicit_imports = true,
+    # `@adapt_structure` is a non-public (un-`public`-declared) macro of Adapt;
+    # ignore until Adapt marks it public.
+    ei_kwargs = (; all_explicit_imports_are_public = (; ignore = (Symbol("@adapt_structure"),))),
+)
+
+# JET is run as a targeted analysis (report_call / report_opt on the public
+# entry points) rather than via run_qa's JET.test_package path: typo-mode
+# package analysis surfaces a JuliaSyntax parentheses warning on the
+# `using EllipsisNotation: EllipsisNotation, (..)` import in src as a toplevel
+# error, which is a tooling artifact, not a defect.
+include("jet.jl")

--- a/test/qa/runtests.jl
+++ b/test/qa/runtests.jl
@@ -1,5 +1,0 @@
-using SafeTestsets
-
-@safetestset "Aqua" include("aqua.jl")
-@safetestset "ExplicitImports" include("explicit_imports.jl")
-@safetestset "JET" include("jet.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,6 @@ run_tests(;
         "Extensions" => joinpath(@__DIR__, "Extensions", "test_symbolics_ext.jl"),
         "GPU" => (; env = joinpath(@__DIR__, "gpu"), body = () -> nothing),
     ),
-    qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "runtests.jl")),
+    qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
     all = ["Core"],
 )


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Brings this repo's QA onto the SciMLTesting 1.6.0 `run_qa` form with ExplicitImports enabled.

## What changed
- Replaced the hand-rolled `test/qa/{aqua,explicit_imports,runtests}.jl` with a single `run_qa(DataInterpolationsND; explicit_imports = true)` call in `test/qa/qa.jl`. Aqua + ExplicitImports come from SciMLTesting's own deps.
- Kept the bespoke JET targeted analysis (`report_call` / `report_opt` on the public entry points) as `test/qa/jet.jl`, included from `qa.jl`. It is **not** routed through `run_qa`'s `JET.test_package` path — see below.
- `test/runtests.jl`: QA group body now points at `qa/qa.jl`.
- `test/qa/Project.toml`: `SciMLTesting` compat -> `"1.6"`; dropped `ExplicitImports` (transitive via SciMLTesting) and `SafeTestsets` (unused in the new `qa.jl`); **kept `Aqua` a direct dep** and **kept `JET`** (see below).

## ExplicitImports findings (6 checks)
- `no_implicit_imports`, `no_stale_explicit_imports`, `all_explicit_imports_via_owners`, `all_qualified_accesses_via_owners`, `all_qualified_accesses_are_public`: **pass clean** — src already imports everything explicitly via `using X: ...`.
- `all_explicit_imports_are_public`: flags `@adapt_structure`, a non-public (un-`public`-declared) macro of **Adapt** that src genuinely uses (`@adapt_structure NDInterpolation`). **Ignored** via `ei_kwargs = (; all_explicit_imports_are_public = (; ignore = (Symbol("@adapt_structure"),)))`, documented in `qa.jl`. Goes away once Adapt marks the macro public.

No `aqua_broken` / `jet_broken` / `ei_broken` are needed — there are no tracked-broken findings to preserve.

## Why JET stays targeted (not via run_qa)
`run_qa`'s only JET path is `JET.test_package(pkg; mode = :typo)`. On this package that hard-fails with a single toplevel "error" that is a JuliaSyntax *parentheses warning* on the `using EllipsisNotation: EllipsisNotation, (..)` import (the `(..)` parens), which typo-mode promotes to a toplevel error. That is a tooling artifact, not a code defect (and the reason this repo never used `test_package`). Marking it `jet_broken` would suppress a non-bug and never auto-clear, so JET keeps the existing targeted `report_call`/`report_opt` coverage of the public entry points.

## Why Aqua stays a direct dep
`Aqua.test_all` runs the ambiguities sub-check via a child process that does `import Aqua`. With Aqua only transitive (via SciMLTesting), that child process fails with "Package Aqua not found in current path" and the `Method ambiguity` test errors. Keeping `Aqua` a direct dep of the QA sub-env fixes it.

## Verification
Ran the QA group against **released SciMLTesting 1.6.0** (Pkg resolves it; no dev-from-branch) on Julia 1.10, 1.11, 1.12 via `GROUP=QA Pkg.test`:

```
Test Summary: | Pass  Total
QA            |   29     29     0 fail / 0 error / 0 broken
```

(Aqua 8 + ExplicitImports 6 + JET static 9 + JET opt 3 + remaining Aqua/project checks = 29.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
