### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolationsND"
 uuid = "4f1ef021-621a-47a5-ac8a-95402a2d1ea8"
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Automated patch version bump (0.1.3 -> 0.1.4) to release unreleased commits on `main` via JuliaRegistrator.