### PR TITLE
Require strict SciMLTesting 2.4 QA

### DIFF
--- a/src/DataInterpolationsND.jl
+++ b/src/DataInterpolationsND.jl
@@ -1,7 +1,7 @@
 module DataInterpolationsND
 using KernelAbstractions: KernelAbstractions, @Const, @index, @kernel, get_backend,
     synchronize
-using Adapt: @adapt_structure
+import Adapt: adapt_structure
 using EllipsisNotation: EllipsisNotation, (..)
 using RecipesBase: RecipesBase, @recipe, @series
 
@@ -55,7 +55,13 @@ function NDInterpolation(u, interp_dims; cache = EmptyCache())
     return NDInterpolation(u, interp_dims, cache)
 end
 
-@adapt_structure NDInterpolation
+function adapt_structure(to, interp::NDInterpolation)
+    return NDInterpolation(
+        adapt_structure(to, interp.u),
+        adapt_structure(to, interp.interp_dims),
+        adapt_structure(to, interp.cache),
+    )
+end
 
 include("interpolation_dimensions.jl")
 include("spline_utils.jl")

--- a/src/interpolation_dimensions.jl
+++ b/src/interpolation_dimensions.jl
@@ -26,7 +26,13 @@ struct LinearInterpolationDimension{
     end
 end
 
-@adapt_structure LinearInterpolationDimension
+function adapt_structure(to, interp_dim::LinearInterpolationDimension)
+    return LinearInterpolationDimension(
+        adapt_structure(to, interp_dim.t),
+        adapt_structure(to, interp_dim.t_eval),
+        adapt_structure(to, interp_dim.idx_eval),
+    )
+end
 
 function LinearInterpolationDimension(t; t_eval = similar(t, 0))
     idx_eval = similar(t_eval, Int)
@@ -69,7 +75,14 @@ struct ConstantInterpolationDimension{
     end
 end
 
-@adapt_structure ConstantInterpolationDimension
+function adapt_structure(to, interp_dim::ConstantInterpolationDimension)
+    return ConstantInterpolationDimension(
+        adapt_structure(to, interp_dim.t),
+        adapt_structure(to, interp_dim.left),
+        adapt_structure(to, interp_dim.t_eval),
+        adapt_structure(to, interp_dim.idx_eval),
+    )
+end
 
 function ConstantInterpolationDimension(t; left = true, t_eval = similar(t, 0))
     idx_eval = similar(t_eval, Int)
@@ -133,7 +146,18 @@ struct BSplineInterpolationDimension{
     end
 end
 
-@adapt_structure BSplineInterpolationDimension
+function adapt_structure(to, interp_dim::BSplineInterpolationDimension)
+    return BSplineInterpolationDimension(
+        adapt_structure(to, interp_dim.t),
+        adapt_structure(to, interp_dim.knots_all),
+        adapt_structure(to, interp_dim.t_eval),
+        adapt_structure(to, interp_dim.idx_eval),
+        adapt_structure(to, interp_dim.degree),
+        adapt_structure(to, interp_dim.max_derivative_order_eval),
+        adapt_structure(to, interp_dim.basis_function_eval),
+        adapt_structure(to, interp_dim.multiplicities),
+    )
+end
 
 function BSplineInterpolationDimension(
         t, degree;

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,11 +1,6 @@
 using SciMLTesting, DataInterpolationsND, Test
 
-run_qa(
-    DataInterpolationsND;
-    # `@adapt_structure` is a non-public (un-`public`-declared) macro of Adapt;
-    # ignore until Adapt marks it public.
-    ei_kwargs = (; all_explicit_imports_are_public = (; ignore = (Symbol("@adapt_structure"),))),
-)
+run_qa(DataInterpolationsND)
 
 # JET is run as a targeted analysis (report_call / report_opt on the public
 # entry points) rather than via run_qa's JET.test_package path: typo-mode

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -1,5 +1,22 @@
 using DataInterpolationsND
+using Adapt
 using Test
+
+struct CopyVectorAdapter end
+
+Adapt.adapt_storage(::Type{CopyVectorAdapter}, values::Vector) = copy(values)
+
+@testset "Adapt integration" begin
+    interp_dim = LinearInterpolationDimension([0.0, 1.0])
+    interp = NDInterpolation([0.0, 1.0], interp_dim)
+    adapted = Adapt.adapt(CopyVectorAdapter, interp)
+
+    @test adapted isa NDInterpolation
+    @test adapted.u == interp.u
+    @test adapted.u !== interp.u
+    @test adapted.interp_dims[1].t == interp.interp_dims[1].t
+    @test adapted.interp_dims[1].t !== interp.interp_dims[1].t
+end
 
 # Interface tests to verify the package properly adheres to Julia's standard interfaces
 # and SciML's array/number interfaces. Uses BigFloat to test numeric type genericity.


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Removes the ExplicitImports allowlist by replacing Adapt’s non-public `@adapt_structure` macro with explicit methods extending the public `Adapt.adapt_structure` API. Adds an adaptation regression test.

Validation:
- Julia 1.12: `Pkg.test()` (637 assertions)
- Julia 1.10: `Pkg.test()` (637 assertions)
- Local strict `run_qa(DataInterpolationsND)`: 20/20; targeted JET: 12/12
- Docs build and `Documenter.doctest(DataInterpolationsND)`: 1/1
- Runic and `git diff --check`