### PR TITLE
docs: enable Documenter doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,6 @@ using Documenter, DataInterpolationsND
 makedocs(
     sitename = "DataInterpolationsND.jl",
     clean = true,
-    doctest = false,
     linkcheck = true,
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],


### PR DESCRIPTION
Remove the repository-level `doctest = false` override so standard Documenter behavior executes the package's documented examples.

Verification:
- `julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'`
- `julia --startup-file=no --project=docs docs/make.jl` (passed with doctests enabled)
- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` (QA: 32/32)
- `julia --startup-file=no -m Runic --check docs/make.jl`
- `typos docs/make.jl`
- `git diff --check`

This is a docs-only configuration change. Please ignore this draft until reviewed by @ChrisRackauckas.