### PR TITLE
Drop stale [compat] majors older than one year

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,9 +18,9 @@ DataInterpolationsNDSymbolicsExt = ["SymbolicUtils", "Symbolics"]
 
 [compat]
 Adapt = "4.3.0"
-DataInterpolations = "8"
+DataInterpolations = "9"
 EllipsisNotation = "1.8.0"
-ForwardDiff = "0"
+ForwardDiff = "1"
 KernelAbstractions = "0.9.34"
 PrecompileTools = "1.2.1"
 Random = "1"


### PR DESCRIPTION
Drop `[compat]` majors whose first General-registry release is older than one year, and keep remaining floors on the latest major.

Policy: SciML minima sit on the latest majors. Extra majors first registered before 2025-08-26 are dropped. Majors first registered after that cutoff are kept (currently: OrdinaryDiffEqCore 4, LinearSolve 4, DiffEqDevTools 3). `julia` and stdlib entries are untouched.

| file | dep | before | after |
|---|---|---|---|
| `Project.toml` | `DataInterpolations` | `8` | `9` |
| `Project.toml` | `ForwardDiff` | `0` | `1` |

OrdinaryDiffEqCore 4 / LinearSolve 4 / DiffEqDevTools 3 are kept where present because they were not in General a year ago.



This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
