### PR TITLE
Fix derivative tests at linear interpolation knots

### DIFF
--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -2,44 +2,62 @@ using DataInterpolationsND
 using ForwardDiff
 using Random
 
-function test_deriv_10(itp, t)
+function test_deriv_10(itp, t, t_ad = t)
     return @test itp(t; derivative_orders = (1, 0)) ≈
-        ForwardDiff.derivative(t₁ -> itp(t₁, t[2]), t[1])
+        ForwardDiff.derivative(t₁ -> itp(t₁, t_ad[2]), t_ad[1])
 end
 
-function test_deriv_01(itp, t)
+function test_deriv_01(itp, t, t_ad = t)
     return @test itp(t; derivative_orders = (0, 1)) ≈
-        ForwardDiff.derivative(t₂ -> itp(t[1], t₂), t[2])
+        ForwardDiff.derivative(t₂ -> itp(t_ad[1], t₂), t_ad[2])
 end
 
-function test_deriv_11(itp, t)
+function test_deriv_11(itp, t, t_ad = t)
     return @test itp(t; derivative_orders = (1, 1)) ≈
         ForwardDiff.derivative(
         t₂ -> ForwardDiff.derivative(
-            t₁ -> itp(t₁, t₂), t[1]
+            t₁ -> itp(t₁, t₂), t_ad[1]
         ),
-        t[2]
+        t_ad[2]
     )
 end
 
-function test_derivatives(itp::NDInterpolation{2})
+function test_derivatives_between_data_points(itp::NDInterpolation{2})
     t1 = itp.interp_dims[1].t
     t2 = itp.interp_dims[2].t
 
-    # Derivatives in data points
-    for t in Iterators.product(t1, t2)
-        test_deriv_10(itp, t)
-        test_deriv_01(itp, t)
-        test_deriv_11(itp, t)
-    end
-
-    # Derivatives between data points
     for t in Iterators.product(
             t1[1:(end - 1)] + diff(t1) / 2, t2[1:(end - 1)] + diff(t2) / 2
         )
         test_deriv_10(itp, t)
         test_deriv_01(itp, t)
         test_deriv_11(itp, t)
+    end
+    return
+end
+
+function test_derivatives_at_data_points(itp::NDInterpolation{2})
+    t1 = itp.interp_dims[1].t
+    t2 = itp.interp_dims[2].t
+    for t in Iterators.product(t1, t2)
+        test_deriv_10(itp, t)
+        test_deriv_01(itp, t)
+        test_deriv_11(itp, t)
+    end
+    return
+end
+
+function test_linear_derivatives_at_data_points(itp::NDInterpolation{2})
+    t1 = itp.interp_dims[1].t
+    t2 = itp.interp_dims[2].t
+    t1_cell = [sum(t1[1:2]) / 2; t1[1:(end - 1)] + diff(t1) / 2]
+    t2_cell = [sum(t2[1:2]) / 2; t2[1:(end - 1)] + diff(t2) / 2]
+
+    # Linear derivatives are undefined at knots, so test the one-sided cell convention.
+    for (t, t_cell) in zip(Iterators.product(t1, t2), Iterators.product(t1_cell, t2_cell))
+        test_deriv_10(itp, t, (t_cell[1], t[2]))
+        test_deriv_01(itp, t, (t[1], t_cell[2]))
+        test_deriv_11(itp, t, t_cell)
     end
     return
 end
@@ -54,7 +72,8 @@ end
         LinearInterpolationDimension(t2),
     )
     itp = NDInterpolation(u, itp_dims)
-    test_derivatives(itp)
+    test_linear_derivatives_at_data_points(itp)
+    test_derivatives_between_data_points(itp)
 end
 
 @testset "BSpline interpolation" begin
@@ -67,7 +86,8 @@ end
         BSplineInterpolationDimension(t2, 2),
     )
     itp = NDInterpolation(u, itp_dims)
-    test_derivatives(itp)
+    test_derivatives_at_data_points(itp)
+    test_derivatives_between_data_points(itp)
 
     u = rand(9, 9)
     itp_dims = (
@@ -75,5 +95,6 @@ end
         BSplineInterpolationDimension(t2, 5),
     )
     itp = NDInterpolation(u, itp_dims)
-    test_derivatives(itp)
+    test_derivatives_at_data_points(itp)
+    test_derivatives_between_data_points(itp)
 end


### PR DESCRIPTION
## What changed and why

ForwardDiff 1 changed `Dual` ordering so equal primal values are ordered by their partials. At a linear-interpolation knot, a positive ForwardDiff seed can therefore select the interval to the right, while `derivative_orders` selects DataInterpolationsND's existing one-sided cell convention. Linear interpolation is not differentiable at an interior knot, so the old test accidentally required ForwardDiff 0.10's former tie-breaking behavior.

This keeps the intended DataInterpolations 9 / ForwardDiff 1 compatibility from https://github.com/SciML/DataInterpolationsND.jl/pull/89. The derivative tests now retain every knot assertion by comparing the explicit knot result with ForwardDiff at an interior point in the same selected cell. Direct ForwardDiff comparisons at differentiable points remain unchanged. No runtime code, public API, or dependency changed.

ForwardDiff's ordering change and rationale are documented in https://github.com/JuliaDiff/ForwardDiff.jl/pull/695.

## Failing before

On Julia 1.10.11 with DataInterpolations 9.4.1 and ForwardDiff 1.4.5:

```text
$ GROUP=Core julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Fail  Total
Derivatives             |  318    51    369
  Linear Interpolation  |   72    51    123
  BSpline interpolation |  246          246
ERROR: Some tests did not pass
```

The dependency boundary reduces to ForwardDiff alone:

```text
ForwardDiff 0.10.39: searchsortedfirst([1.0, 2.0, 3.0], Dual(2.0, 1.0)) = 2
ForwardDiff 1.4.5:  searchsortedfirst([1.0, 2.0, 3.0], Dual(2.0, 1.0)) = 3
```

## Passing after

Latest compatible dependencies on Julia 1.10.11 (DataInterpolations 9.4.1, ForwardDiff 1.4.5):

```text
Interpolations      | 206 / 206
Derivatives         | 369 / 369
DataInterpolations  |  28 / 28
Interface           |  34 / 34
Testing DataInterpolationsND tests passed
```

The exact downgrade workflow resolved DataInterpolations 9.0.0 and ForwardDiff 1.0.0. `GROUP=Core ... Pkg.test(; allow_reresolve=false)` produced the same 637/637 passing assertions.

The same Core group also passed on Julia 1.12.7 and Julia 1.13.0-rc2. `GROUP=QA` passed 32/32 on Julia 1.12.7.

Formatting and spelling:

```text
Runic 1.9.0 --check: 18 / 18 Julia files formatted
typos Project.toml test/test_derivatives.jl: exit 0
git diff --check: exit 0
```

## Existing failure and unverified paths

- `GROUP=QA` on Julia 1.10.11 fails on the unmodified base behavior because `unwrap` is imported through `Symbolics` while ExplicitImports identifies `SymbolicUtils` as its owner. The clean-main investigation bisected that failure to https://github.com/SciML/DataInterpolationsND.jl/commit/6c1731080794762d94e5b82fcba29499436ba18e and opened the independently validated fix at https://github.com/SciML/DataInterpolationsND.jl/pull/92; this unrelated owner-import change is intentionally not mixed into this PR.
- Documentation was not built because no docs, docstrings, or public API changed.
- GPU tests were not run locally.

## Reviewer judgment call

This treats differentiation exactly at a piecewise-linear knot as a test-domain issue, not a ForwardDiff runtime bug. Overriding ForwardDiff 1's directional branch choice would impose an arbitrary derivative where none exists and would currently require relying on non-public `ForwardDiff.Dual` / `ForwardDiff.value` internals.

This PR should be ignored until reviewed by @ChrisRackauckas.

AI-Agent: OpenAI Codex

Codex-Session-ID: 01a03e8f-9411-7bc1-9d30-b25b6976ac8d

## Links

- This draft PR: https://github.com/SciML/DataInterpolationsND.jl/pull/90
- ForwardDiff ordering change: https://github.com/JuliaDiff/ForwardDiff.jl/pull/695
- Latest-major compat PR: https://github.com/SciML/DataInterpolationsND.jl/pull/89
- Separate base-branch QA fix: https://github.com/SciML/DataInterpolationsND.jl/pull/92

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03e8f-9411-7bc1-9d30-b25b6976ac8d
