### PR TITLE
Fix ForwardDiff 1 Dual interval lookup at knots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,10 +10,12 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [weakdeps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [extensions]
+DataInterpolationsNDForwardDiffExt = "ForwardDiff"
 DataInterpolationsNDSymbolicsExt = ["SymbolicUtils", "Symbolics"]
 
 [compat]
@@ -30,7 +32,7 @@ SciMLTesting = "2.4"
 SymbolicUtils = "4"
 Symbolics = "7"
 Test = "1"
-julia = "1"
+julia = "1.10"
 
 [extras]
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"

--- a/ext/DataInterpolationsNDForwardDiffExt.jl
+++ b/ext/DataInterpolationsNDForwardDiffExt.jl
@@ -1,0 +1,10 @@
+module DataInterpolationsNDForwardDiffExt
+
+using DataInterpolationsND
+using ForwardDiff: ForwardDiff
+
+function DataInterpolationsND.search_value(d::ForwardDiff.Dual)
+    return DataInterpolationsND.search_value(ForwardDiff.value(d))
+end
+
+end

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -47,7 +47,9 @@ function _interpolate!(
         multi_point_index
     ) where {N_in, N_out, ID <: ConstantInterpolationDimension}
     if any(>(0), derivative_orders)
-        return if any(i -> !isempty(searchsorted(A.interp_dims[i].t, t[i])), 1:N_in)
+        return if any(
+                i -> !isempty(searchsorted(A.interp_dims[i].t, search_value(t[i]))), 1:N_in
+            )
             typed_nan(out)
         else
             out
@@ -55,7 +57,7 @@ function _interpolate!(
     end
     # Use a new variable to avoid shadowing/capturing idx in the ntuple closure
     idx_adjusted = ntuple(N_in) do i
-        t[i] >= A.interp_dims[i].t[end] ? length(A.interp_dims[i].t) : idx[i]
+        search_value(t[i]) >= A.interp_dims[i].t[end] ? length(A.interp_dims[i].t) : idx[i]
     end
     if iszero(N_out)
         out = A.u[idx_adjusted...]

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -112,6 +112,9 @@ end
 get_idx_shift(::AbstractInterpolationDimension) = 0
 get_idx_shift(::LinearInterpolationDimension) = -1
 
+# ForwardDiff 1 Dual comparisons include partials; search on the primal (see ForwardDiff ext).
+search_value(x) = x
+
 # TODO: Implement a more efficient (GPU compatible) version
 function get_idx(
         interp_dim::AbstractInterpolationDimension,
@@ -122,14 +125,15 @@ function get_idx(
     else
         interp_dim.t
     end
+    t_query = search_value(t_eval)
     left = get_left(interp_dim)
     lb, ub_shift = get_idx_bounds(interp_dim)
     idx_shift = get_idx_shift(interp_dim)
     ub = length(t) + ub_shift
     return if left
-        clamp(searchsortedfirst(t, t_eval) + idx_shift, lb, ub)
+        clamp(searchsortedfirst(t, t_query) + idx_shift, lb, ub)
     else
-        clamp(searchsortedlast(t, t_eval) + idx_shift, lb, ub)
+        clamp(searchsortedlast(t, t_query) + idx_shift, lb, ub)
     end
 end
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DataInterpolationsND = "4f1ef021-621a-47a5-ac8a-95402a2d1ea8"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
@@ -10,6 +11,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 DataInterpolationsND = "0.1"
+ForwardDiff = "1"
 JET = "0.9, 0.10, 0.11.2, 0.12"
 SciMLTesting = "2.4"
 SymbolicUtils = "4"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,8 +1,8 @@
 using SciMLTesting, DataInterpolationsND, Test
 
 # ExplicitImports only sees an extension module once its triggers are loaded, so the
-# weakdeps have to be brought in here for DataInterpolationsNDSymbolicsExt to be checked.
-using SymbolicUtils, Symbolics
+# weakdeps have to be brought in here for the extensions to be checked.
+using ForwardDiff, SymbolicUtils, Symbolics
 
 run_qa(
     DataInterpolationsND;
@@ -17,9 +17,12 @@ run_qa(
                 # Symbolics: `SymbolicT` is the unwrapped symbolic type the generated
                 # interpolation call methods dispatch on; there is no public spelling.
                 :SymbolicT,
-                # DataInterpolationsND's own internal helper, reached from its own
-                # extension module.
-                :get_output_size,
+                # DataInterpolationsND's own internal helpers, reached from its own
+                # extension modules.
+                :get_output_size, :search_value,
+                # ForwardDiff: Dual and its primal accessor are not marked public;
+                # keep them allowed until ForwardDiff declares them public.
+                :Dual, :value,
             ),
         ),
     ),

--- a/test/test_derivatives.jl
+++ b/test/test_derivatives.jl
@@ -55,6 +55,17 @@ end
     )
     itp = NDInterpolation(u, itp_dims)
     test_derivatives(itp)
+
+    for t in Iterators.product(t1, t2)
+        idx = DataInterpolationsND.get_idx(itp.interp_dims, t)
+        @test idx ==
+            DataInterpolationsND.get_idx(itp.interp_dims, (ForwardDiff.Dual(t[1], 1.0), t[2]))
+        @test idx ==
+            DataInterpolationsND.get_idx(itp.interp_dims, (t[1], ForwardDiff.Dual(t[2], 1.0)))
+        @test idx == DataInterpolationsND.get_idx(
+            itp.interp_dims, (ForwardDiff.Dual(t[1], -1.0), t[2])
+        )
+    end
 end
 
 @testset "BSpline interpolation" begin


### PR DESCRIPTION
ForwardDiff 1 Dual comparisons include partials, so interval search could choose a different cell for a Dual query than for the corresponding scalar query at an interpolation knot. Interval lookup now uses the recursively unwrapped primal value, and the package now requires Julia 1.10.

## What changed and why

ForwardDiff changed Dual equality in [JuliaDiff/ForwardDiff.jl#481](https://github.com/JuliaDiff/ForwardDiff.jl/pull/481) and made `isless`/ordering consistent with that equality in [JuliaDiff/ForwardDiff.jl#695](https://github.com/JuliaDiff/ForwardDiff.jl/pull/695). Consequently, `Dual(knot, 1.0) > knot`, and `searchsortedfirst` can select the cell to the right of the one selected by a scalar query.

DataInterpolationsND's linear interval lookup uses `searchsortedfirst` with `idx_shift = -1`, which establishes a left-cell convention at exact knots. `get_idx` and Constant interpolation's knot checks now search on `search_value(t)`. A ForwardDiff extension recursively unwraps Dual queries for interval selection while leaving Dual arithmetic in the interpolation formula unchanged.

A piecewise-linear derivative is not mathematically defined at an interior knot. This PR does not claim otherwise. Derivative behavior should be compared at points strictly inside the cells immediately to either side of a knot; those evaluations agree across supported ForwardDiff versions. The exact-knot tests in this PR verify only that scalar and Dual queries follow the same deterministic interval-selection convention.

Julia 1.10 is now the minimum supported Julia version. This matches the native package-extension mechanism used for the ForwardDiff integration and the current ForwardDiff 1.x release line.

## Fail-then-pass evidence

Julia 1.10.11, DataInterpolations 9.4.1, and ForwardDiff 1.4.5. Linear test data comes from `test/test_derivatives.jl` (`t1 = [1.0, 2.0, 3.5, 4.0, 10.0]`, `t2 = [-1.5, 0.0, 2.5, 7.8, 12.9]`).

Before the fix, at the interior knot `t = (2.0, 0.0)`:

| Query | `get_idx` |
|---|---|
| Scalar | `(1, 1)` |
| Dual in `t1` with seed `+1` | `(2, 1)` |

That mismatch produced 51 exact-knot failures in the linear derivative comparisons:

```text
Linear Interpolation: Test Summary: 72 passed, 51 failed, 0 errored, 0 broken
```

With this PR, scalar and Dual queries use `(1, 1)` at the same knot. The new assertions cover every knot with positive and negative Dual seeds.

## Verification

`GROUP=Core /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`:

```text
Test Summary:  | Pass  Total  Time
Interpolations |  206    206  7.0s
Test Summary: | Pass  Total  Time
Derivatives   |  444    444  4.8s
Test Summary:      | Pass  Total  Time
DataInterpolations |   28     28  4.1s
Test Summary: | Pass  Total  Time
Interface     |   34     34  7.5s
     Testing DataInterpolationsND tests passed
```

Additional local checks:

```text
Runic 1.9.0 --check src ext test docs: exit 0
typos over the diff: exit 0
git diff --check: exit 0
```

`GROUP=QA` reaches 29 passes and one pre-existing error on unmodified `origin/main`: `DataInterpolationsNDSymbolicsExt` imports `unwrap` through `Symbolics` while ExplicitImports identifies `SymbolicUtils` as its owner. The independently validated fix is [PR #92](https://github.com/SciML/DataInterpolationsND.jl/pull/92). This unrelated owner-import change is not mixed into this PR.

## What was not verified

- GPU group: no GPU was available locally.
- Downstream packages.
- Documentation build: this PR changes no docs, docstrings, or public API.
- Allowed-to-fail jobs such as `julia pre`.

## Compat and dependency API

| Dependency | Compat |
|---|---|
| Julia | `"1.10"` |
| DataInterpolations | `"9"` |
| ForwardDiff | `"1"` |

ForwardDiff is an MIT-licensed weak dependency. `ForwardDiff.Dual` and `ForwardDiff.value` are intentionally listed in the ExplicitImports allowlist for this extension; that exception was approved during review.

This PR should be ignored until reviewed by @ChrisRackauckas.

AI-Agent: OpenAI Codex

Codex-Session-ID: 01a03f46-2e26-7f63-a41e-1ebf5b0729e4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03f46-2e26-7f63-a41e-1ebf5b0729e4
