### PR TITLE
Import unwrap from its owning module

### DIFF
--- a/ext/DataInterpolationsNDSymbolicsExt.jl
+++ b/ext/DataInterpolationsNDSymbolicsExt.jl
@@ -2,8 +2,9 @@ module DataInterpolationsNDSymbolicsExt
 
 import DataInterpolationsND
 using DataInterpolationsND: NDInterpolation
-using Symbolics: Symbolics, Num, unwrap, @register_derivative
+using Symbolics: Symbolics, Num, @register_derivative
 import SymbolicUtils
+using SymbolicUtils: unwrap
 
 struct DifferentiatedNDInterpolation{N_in, N_out, I <: NDInterpolation{N_in, N_out}}
     interp::I

--- a/test/Extensions/test_symbolics_ext.jl
+++ b/test/Extensions/test_symbolics_ext.jl
@@ -1,7 +1,7 @@
 using DataInterpolationsND
 using Symbolics
 import SymbolicUtils as SU
-using Symbolics: unwrap
+using SymbolicUtils: unwrap
 using Test
 
 t1 = cumsum(rand(5))


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The Symbolics extension imported `unwrap` through the `Symbolics` reexport, although the binding is owned and declared public by `SymbolicUtils`. Julia 1.10 exposes that ownership through `Base.which`, so ExplicitImports correctly rejects the non-owner import; Julia 1.12 did not expose the same result in this check.

Import `unwrap` directly from `SymbolicUtils` in both the extension and its tests. This changes no runtime behavior or public API.

## Root cause and bisect

`git bisect run` identified https://github.com/SciML/DataInterpolationsND.jl/commit/6c1731080794762d94e5b82fcba29499436ba18e as the first bad repository commit. That commit made QA load and scan the Symbolics extension, but retained the non-owner `Symbolics.unwrap` import.

## Regression evidence

Unfixed `upstream/main` (`b9546c7`), Julia 1.10.11:

```text
$ GROUP=QA ~/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
ExplicitImportsFromNonOwnerException
- `unwrap` has owner `SymbolicUtils` but it was imported from `Symbolics`
Test Summary: | Pass  Error  Total
QA            |   29      1     30
```

With this fix, the same command and Julia version:

```text
Test Summary: | Pass  Total   Time
QA            |   30     30  30.1s
Testing DataInterpolationsND tests passed
```

## Additional verification

```text
$ GROUP=Extensions ~/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Extensions    |   23     23  11.3s
Testing DataInterpolationsND tests passed

$ GROUP=QA ~/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   32     32  1m47.3s
Testing DataInterpolationsND tests passed

$ ~/.juliaup/bin/julia +1.12 --project=@runic117 -m Runic --check ext/DataInterpolationsNDSymbolicsExt.jl test/Extensions/test_symbolics_ext.jl
# exit 0

$ git diff --no-ext-diff --unified=0 | typos -
# exit 0
```

## Not verified

- Docs were not built because the change does not touch docs, docstrings, or public API.
- GPU, downstream, and `GROUP=Everything` jobs were not run because this only corrects an extension import source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03e8f-9411-7bc1-9d30-b25b6976ac8d
